### PR TITLE
Fix for snmp-collector and contrail-topology

### DIFF
--- a/contrail-analytics/templates/configmap-env.yaml
+++ b/contrail-analytics/templates/configmap-env.yaml
@@ -9,10 +9,9 @@ kind: ConfigMap
 metadata:
   name: configmap-analytics
 data:
-  CONTROLLER_NODES: {{ .Values.conf.controller_nodes }}
-  LOG_LEVEL: {{ .Values.conf.log_level }}
-  ZOOKEEPER_ANALYTICS_PORT: "2181"
-  ZOOKEEPER_ANALYTICS_SERVERS: "10.87.65.248:2181"
+  CONTROLLER_NODES: {{ .Values.conf.controller_nodes | quote }}
+  LOG_LEVEL: {{ .Values.conf.log_level | quote }}
+  ZOOKEEPER_ANALYTICS_PORT: {{ .Values.conf.analytics_zookeeper.port | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/contrail-analytics/values.yaml
+++ b/contrail-analytics/values.yaml
@@ -34,6 +34,9 @@ conf:
   rabbitmq:
     use_ssl: False
 
+  analytics_zookeeper:
+    port: 2181
+
 # typically overriden by environmental
 # values, but should include all endpoints
 # required by this chart


### PR DESCRIPTION
Configuring the analytics_zookeeper_port from values.yaml file of
contrail-analytics chart