### PR TITLE
Configuring each contrail service as a different pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,104 @@
-# contrail-helm-deployer
-Contrail Helm based deployment
+# Contrail Helm based deployment
+
+This repo consists of contrail helm charts which helps to deploy contrail networking components as microservices
+
+___
+
+## Architecure of contrail helm charts
+
+Contrail-helm-deployer is divided into below charts
+
+1. contrail-helper: Is a chart where common methods used in other contrail charts are defined. contrail-helper chart is a common requirement for every other chart
+2. contrail-thrirdparty: Helps to install contrail thirdparty components like cassandra, zookepper, kafka and redis needed by other contrail charts
+3. contrail-controller: Using this chart we can install contrail services related to config, control and webui components
+4. contrail-analytics: Helps to install contrail analytics services
+5. contrail-vrouter: Installs contrail vrouter services
+
+Using .Values.manifests.each_container_is_pod variable we can make each contrail service run as a single pod. Otherwise services under control, config, webui, analytics and vrouter components are grouped into a pod
+
+## Prerequisites
+
+* Centos 7.4
+* Centos kernel version: 3.10.0-693.5.2.el7.x86_64
+* Docker version: Tested with 1.12.6
+* helm version: Tested with v2.5.1
+* kubernetes version: Tested with v1.7.4
+* Have kubernetes cluster up and running
+* Have openstack-helm charts up and running (To-do steps to bring up openstack-helm charts, with contrail related changes in it)
+
+___
+
+## Instructions to bring up contrail helm charts
+
+1. Get the helm charts by cloning the repository
+
+  ```console
+  git clone https://github.com/Juniper/contrail-helm-deployer.git
+  cd contrail-helm-deployer
+  export WORK_DIR=$(pwd)
+  ```
+
+2. Make sure that you have helm server up and running (This is done while installing openstack-helm charts). Below is how you verify installation of helm server
+  ```console
+  $ helm repo list
+  NAME    URL
+  local   http://localhost:8879/charts
+  ```
+
+3. Use `make` command to initialize, build up the dependency and lint the charts
+  ```console
+  make
+  ```
+
+4. Edit below values.yaml file to change the IP of controller_nodes and also to point it to the correct docker_registry
+  ```console
+  vim contrail-thirdparty/values.yaml
+  vim contrail-controller/values.yaml
+  vim contrail-analytics/values.yaml
+  vim contrail-vrouter/values.yaml
+  ```
+
+5. Install contrail components using the below command
+  ```console
+  helm install --name contrail-thirdparty \
+  ${WORK_DIR}/contrail-thirdparty --namespace=openstack \
+  --set manifests.each_container_is_pod=true
+  #
+  helm install --name contrail-controller \
+  ${WORK_DIR}/contrail-controller --namespace=openstack \
+  --set manifests.each_container_is_pod=true
+  #
+  helm install --name contrail-analytics \
+  ${WORK_DIR}/contrail-analytics --namespace=openstack \
+  --set manifests.each_container_is_pod=true
+  #
+  helm install --name contrail-vrouter \
+  ${WORK_DIR}/contrail-vrouter --namespace=openstack \
+  --set manifests.each_container_is_pod=true
+  ```
+
+___
+
+## To-Do list
+
+1. ~~Coming up with basic charts, adding Makefile and trying it with openstack-helm charts~~
+2. ~~Having an option to deploy each container as a separate pod~~
+3. ~~Separating out config-zookeeper and analytics-zookeeper~~
+4. Exposing all ports used by each container in the container spec
+5. Analyzing and adding resource limits for each of the contrail container
+6. Adding lifecycle hooks to each of the container and making sure that we delete everything we create while deleting the container
+7. Adding charts for DPDK vrouter
+8. Support for SRIOV and SRIOV+DPDK coexistence using helm
+9. Evaluating headless services for NB APIs and webui in contrail
+10. Documentation for Contrail Helm charts in 5.0
+  * Installation doc
+  * High level Architecture doc for 5.0 charts
+  * Troubleshooting 5.0 helm charts docs
+11. Adding RBAC objects for each of the pod
+12. Adding contrail-kubernetes related components
+13. Support for adding TSN node
+14. Test adding single vrouter at a time
+15. Test contrail HA
+16. Adding test cases for each of helm charts
+17. Support for provisioning hybrid cloud connect
+18. Patching contrail changes with the latest openstack-helm charts

--- a/contrail-analytics/templates/daemonset-alarm-gen.yaml
+++ b/contrail-analytics/templates/daemonset-alarm-gen.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-alarm-gen
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-alarm-gen" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.alarm_gen | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-alarm-gen
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_alarm_gen .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        - configMapRef:
+            name: configmap-analytics-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-analytics-api.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-api.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-analytics" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.analytics | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-analytics-api
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_api .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-analytics-collector.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-collector.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-collector
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-collector" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.collector | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-collector
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_collector .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        - configMapRef:
+            name: configmap-analytics-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-analytics-nodemgr.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-nodemgr.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-analytics-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-analytics-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.analytics_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-analytics-nodemgr
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        env:
+        - name: NODE_TYPE
+          value: analytics
+        - name: DOCKER_HOST
+          value: "unix://mnt/docker.sock"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-analytics.yaml
+++ b/contrail-analytics/templates/daemonset-analytics.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.manifests.each_container_is_pod }}
 {{- if .Values.manifests.daemonset_analytics }}
 {{- $context := . }}
 ---
@@ -109,4 +110,5 @@ spec:
       - name: docker-unix-socket
         hostPath:
           path: /var/run
+{{- end }}
 {{- end }}

--- a/contrail-analytics/templates/daemonset-query-engine.yaml
+++ b/contrail-analytics/templates/daemonset-query-engine.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-query-engine
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-query-engine" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.query_engine | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-query-engine
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_query_engine .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-snmp-collector.yaml
+++ b/contrail-analytics/templates/daemonset-snmp-collector.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-snmp-collector
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-snmp-collector" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.snmp_collector | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-snmp-collector
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_snmp_collector .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        - configMapRef:
+            name: configmap-analytics-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/templates/daemonset-topology.yaml
+++ b/contrail-analytics/templates/daemonset-topology.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_analytics }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-topology
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-topology" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.analytics.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.analytics.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.topology | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-topology
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.analytics_topology .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-analytics
+        - configMapRef:
+            name: configmap-analytics-auth
+        - configMapRef:
+            name: configmap-analytics-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-analytics/values.yaml
+++ b/contrail-analytics/values.yaml
@@ -21,6 +21,24 @@ dependencies:
   analytics:
     daemonset:
     - contrail-analyticsdb
+  collector:
+    daemonset:
+    - contrail-analytics
+  alarm_gen:
+    daemonset:
+    - contrail-analytics
+  query_engine:
+    daemonset:
+    - contrail-analytics
+  snmp_collector:
+    daemonset:
+    - contrail-analytics
+  topology:
+    daemonset:
+    - contrail-analytics
+  analytics_nodemgr:
+    daemonset:
+    - contrail-analytics
 
 conf:
   # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
@@ -73,5 +91,6 @@ endpoints:
     protocol: http
 
 manifests:
+  each_container_is_pod: true
   configmap_env: true
   daemonset_analytics: true

--- a/contrail-controller/templates/daemonset-config-api.yaml
+++ b/contrail-controller/templates/daemonset-config-api.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.daemonset_config .Values.manifests.each_container_is_pod }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-config
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-config-api" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.config | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-config-api
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_api .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-config-nodemgr.yaml
+++ b/contrail-controller/templates/daemonset-config-nodemgr.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.manifests.daemonset_config .Values.manifests.each_container_is_pod }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-config-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-config-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.config_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-config-nodemgr
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        env:
+        - name: NODE_TYPE
+          value: config
+        - name: DOCKER_HOST
+          value: "unix://mnt/docker.sock"
+        volumeMounts:
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-config.yaml
+++ b/contrail-controller/templates/daemonset-config.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.manifests.each_container_is_pod }}
 {{- if .Values.manifests.daemonset_config }}
 {{- $context := . }}
 ---
@@ -38,6 +39,9 @@ spec:
             name: configmap-controller-auth
         - configMapRef:
             name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
       - name: contrail-devicemgr
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_devicemgr .Values.images.tags.contrail_version | quote }}
         imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -48,6 +52,9 @@ spec:
             name: configmap-controller-auth
         - configMapRef:
             name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
       - name: contrail-schema-transformer
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_schema_transformer .Values.images.tags.contrail_version | quote }}
         imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -58,6 +65,9 @@ spec:
             name: configmap-controller-auth
         - configMapRef:
             name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
       - name: contrail-svcmonitor
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_svcmonitor .Values.images.tags.contrail_version | quote }}
         imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -68,6 +78,9 @@ spec:
             name: configmap-controller-auth
         - configMapRef:
             name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
       - name: contrail-config-nodemgr
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
         imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -89,8 +102,14 @@ spec:
         volumeMounts:
         - mountPath: /mnt
           name: docker-unix-socket
+        - mountPath: /var/log/contrail/
+          name: contrail-log
       volumes:
       - name: docker-unix-socket
         hostPath:
           path: /var/run
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}
 {{- end }}

--- a/contrail-controller/templates/daemonset-control-nodemgr.yaml
+++ b/contrail-controller/templates/daemonset-control-nodemgr.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_control }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-control-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.control_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-control-nodemgr
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        env:
+        - name: NODE_TYPE
+          value: control
+        - name: DOCKER_HOST
+          value: "unix://mnt/docker.sock"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-control-only.yaml
+++ b/contrail-controller/templates/daemonset-control-only.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_control }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-control
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-control" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.control | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-control
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.control_control .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-control.yaml
+++ b/contrail-controller/templates/daemonset-control.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.manifests.each_container_is_pod }}
 {{- if .Values.manifests.daemonset_control }}
 {{- $context := . }}
 ---
@@ -26,7 +27,7 @@ spec:
         effect: NoSchedule
       hostNetwork: true
       initContainers:
-{{ tuple $context .Values.dependencies.config | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.control | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-control
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.control_control .Values.images.tags.contrail_version | quote }}
@@ -85,4 +86,5 @@ spec:
       - name: docker-unix-socket
         hostPath:
           path: /var/run
+{{- end }}
 {{- end }}

--- a/contrail-controller/templates/daemonset-devicemgr.yaml
+++ b/contrail-controller/templates/daemonset-devicemgr.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.daemonset_config .Values.manifests.each_container_is_pod }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-devicemgr
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-devicemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.devicemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-devicemgr
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_devicemgr .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-dns.yaml
+++ b/contrail-controller/templates/daemonset-dns.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_control }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-dns
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-dns" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.contrail_dns | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-dns
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.control_dns .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-named.yaml
+++ b/contrail-controller/templates/daemonset-named.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_control }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-named
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-named" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.contrail_named | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-named
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.control_named .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-schema-transformer.yaml
+++ b/contrail-controller/templates/daemonset-schema-transformer.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.daemonset_config .Values.manifests.each_container_is_pod }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-schema-transformer
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-schema-transformer" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.schema_transformer | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-schema-transformer
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_schema_transformer .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-svcmonitor.yaml
+++ b/contrail-controller/templates/daemonset-svcmonitor.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.manifests.daemonset_config .Values.manifests.each_container_is_pod }}
+{{- $context := . }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-svcmonitor
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-svcmonitor" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.controller.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.controller.node_selector_value }}
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.svcmonitor | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-svc-monitor
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.config_svcmonitor .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-controller
+        - configMapRef:
+            name: configmap-controller-auth
+        - configMapRef:
+            name: configmap-controller-rabbitmq
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-controller/templates/daemonset-webui-middleware.yaml
+++ b/contrail-controller/templates/daemonset-webui-middleware.yaml
@@ -1,16 +1,15 @@
-{{- if not .Values.manifests.each_container_is_pod }}
-{{- if .Values.manifests.daemonset_webui }}
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_webui }}
 {{- $context := . }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: contrail-webui
+  name: contrail-webui-middleware
 spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-webui" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-webui-middleware" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +26,7 @@ spec:
         effect: NoSchedule
       hostNetwork: true
       initContainers:
-{{ tuple $context .Values.dependencies.webui | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.webui_middleware | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-webui-middleware
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.webui_middleware .Values.images.tags.contrail_version | quote }}
@@ -37,13 +36,11 @@ spec:
             name: configmap-controller
         - configMapRef:
             name: configmap-controller-auth
-      - name: contrail-webui
-        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.webui .Values.images.tags.contrail_version | quote }}
-        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
-        envFrom:
-        - configMapRef:
-            name: configmap-controller
-        - configMapRef:
-            name: configmap-controller-auth
-{{- end }}
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
 {{- end }}

--- a/contrail-controller/templates/daemonset-webui.yaml
+++ b/contrail-controller/templates/daemonset-webui.yaml
@@ -1,5 +1,4 @@
-{{- if not .Values.manifests.each_container_is_pod }}
-{{- if .Values.manifests.daemonset_webui }}
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_webui }}
 {{- $context := . }}
 ---
 apiVersion: extensions/v1beta1
@@ -29,14 +28,6 @@ spec:
       initContainers:
 {{ tuple $context .Values.dependencies.webui | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
       containers:
-      - name: contrail-webui-middleware
-        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.webui_middleware .Values.images.tags.contrail_version | quote }}
-        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
-        envFrom:
-        - configMapRef:
-            name: configmap-controller
-        - configMapRef:
-            name: configmap-controller-auth
       - name: contrail-webui
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.webui .Values.images.tags.contrail_version | quote }}
         imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -45,5 +36,11 @@ spec:
             name: configmap-controller
         - configMapRef:
             name: configmap-controller-auth
-{{- end }}
+        volumeMounts:
+        - mountPath: /var/log/contrail/
+          name: contrail-log
+      volumes:
+      - name: contrail-log
+        hostPath:
+          path: /var/log/contrail/
 {{- end }}

--- a/contrail-controller/values.yaml
+++ b/contrail-controller/values.yaml
@@ -10,8 +10,8 @@ images:
     config_devicemgr: "contrail-controller-config-devicemgr"
     config_schema_transformer: "contrail-controller-config-schema"
     config_svcmonitor: "contrail-controller-config-svcmonitor"
-    webui_job: "contrail-controller-webui-job"
-    webui_web: "contrail-controller-webui-web"
+    webui_middleware: "contrail-controller-webui-job"
+    webui: "contrail-controller-webui-web"
     dep_check: quay.io/stackanetes/kubernetes-entrypoint:v0.2.1
   imagePullPolicy: "IfNotPresent"
 
@@ -24,13 +24,41 @@ dependencies:
   config:
     daemonset:
     - contrail-configdb
+  schema_transformer:
+    daemonset:
+    - contrail-config
+  svcmonitor:
+    daemonset:
+    - contrail-config
+  devicemgr:
+    daemonset:
+    - contrail-config
+  config_nodemgr:
+    daemonset:
+    - contrail-config
   control:
     daemonset:
+    - contrail-config
+  contrail_named:
+    daemonset:
+    - contrail-control
+    - contrail-config
+  contrail_dns:
+    daemonset:
+    - contrail-control
+    - contrail-config
+  control_nodemgr:
+    daemonset:
+    - contrail-control
     - contrail-config
   webui:
     daemonset:
     - contrail-config
     - contrail-redis
+  webui_middleware:
+    daemonset:
+    - contrail-config
+    - contrail-webui
 
 conf:
   # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
@@ -80,6 +108,7 @@ endpoints:
     protocol: http
 
 manifests:
+  each_container_is_pod: true
   configmap_env: true
   daemonset_config: true
   daemonset_control: true

--- a/contrail-thirdparty/templates/configmap-env.yaml
+++ b/contrail-thirdparty/templates/configmap-env.yaml
@@ -61,8 +61,8 @@ data:
   CASSANDRA_START_RPC: "true"
   CASSANDRA_LISTEN_ADDRESS: {{ .Values.conf.analyticsdb_nodes | default $controller_nodes | quote }}
   JVM_EXTRA_OPTS: >-
-    -Dcassandra.rpc_port={{ .Values.conf.configdb.rpc_port }}
-    -Dcassandra.native_transport_port={{ .Values.conf.configdb.cql_port }}
+    -Dcassandra.rpc_port={{ .Values.conf.analyticsdb.rpc_port }}
+    -Dcassandra.native_transport_port={{ .Values.conf.analyticsdb.cql_port }}
     -Dcassandra.ssl_storage_port=7001
     -Dcassandra.storage_port=7000
     -Xms2G -Xmx2G

--- a/contrail-vrouter/templates/daemonset-agent-only.yaml
+++ b/contrail-vrouter/templates/daemonset-agent-only.yaml
@@ -1,5 +1,4 @@
-{{- if not .Values.manifests.each_container_is_pod }}
-{{- if .Values.manifests.daemonset_agent }}
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_agent }}
 {{- $context := . }}
 # host_os is a mandatory field
 {{- $_ := required ".Values.conf.host_os must be specified, valid values are ubuntu, centos" .Values.conf.host_os }}
@@ -13,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-agent" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-vrouter-agent" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
     spec:
       #Disable affinity for single node setup
       affinity:
@@ -32,7 +31,7 @@ spec:
         effect: NoSchedule
       hostNetwork: true
       initContainers:
-{{ tuple $context .Values.dependencies.agent | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.vrouter_agent | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
         - name: contrail-agent-init-kernel
           image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.agent_vrouter_init_kernel .Values.images.tags.contrail_version | quote }}
           imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
@@ -64,31 +63,9 @@ spec:
           name: lib-modules
         - mountPath: /var/lib/contrail/
           name: var-lib-contrail
-      - name: contrail-agent-nodemgr
-        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
-        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
-        envFrom:
-        - configMapRef:
-            name: configmap-vrouter
-        - configMapRef:
-            name: configmap-vrouter-auth
-        env:
-        - name: NODE_TYPE
-          value: vrouter
-        - name: DOCKER_HOST
-          value: "unix://mnt/docker.sock"
-# todo: there is type Socket in new kubernetes, it is possible to use full
-# path:
-# hostPath:
-#   path: /var/run/docker.sock and
-#   type: Socket
-        volumeMounts:
-        - mountPath: /mnt
-          name: docker-unix-socket
+        - mountPath: /var/log/contrail
+          name: var-log-contrail
       volumes:
-      - name: docker-unix-socket
-        hostPath:
-          path: /var/run
       - name: usr-src
         hostPath:
           path: /usr/src
@@ -98,5 +75,7 @@ spec:
       - name: var-lib-contrail
         hostPath:
           path: /var/lib/contrail/
-{{- end }}
+      - name: var-log-contrail
+        hostPath:
+          path: /var/log/contrail/
 {{- end }}

--- a/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
+++ b/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
@@ -1,0 +1,66 @@
+{{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_agent }}
+{{- $context := . }}
+# host_os is a mandatory field
+{{- $_ := required ".Values.conf.host_os must be specified, valid values are ubuntu, centos" .Values.conf.host_os }}
+{{- $host_os := .Values.conf.host_os }}
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-vrouter-nodemgr
+spec:
+  template:
+    metadata:
+      labels:
+{{ tuple $context "opencontrail" "contrail-vrouter-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+    spec:
+      #Disable affinity for single node setup
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.labels.agent.node_selector_key }}
+                operator: In
+                values:
+                - {{ .Values.labels.agent.node_selector_value }}
+      #Enable tolerations for single node setup
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      hostNetwork: true
+      initContainers:
+{{ tuple $context .Values.dependencies.vrouter_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+      containers:
+      - name: contrail-agent-nodemgr
+        image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.nodemgr .Values.images.tags.contrail_version | quote }}
+        imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}
+        envFrom:
+        - configMapRef:
+            name: configmap-vrouter
+        - configMapRef:
+            name: configmap-vrouter-auth
+        env:
+        - name: NODE_TYPE
+          value: vrouter
+        - name: DOCKER_HOST
+          value: "unix://mnt/docker.sock"
+# todo: there is type Socket in new kubernetes, it is possible to use full
+# path:
+# hostPath:
+#   path: /var/run/docker.sock and
+#   type: Socket
+        volumeMounts:
+        - mountPath: /mnt
+          name: docker-unix-socket
+        - mountPath: /var/log/contrail
+          name: var-log-contrail
+      volumes:
+      - name: docker-unix-socket
+        hostPath:
+          path: /var/run
+      - name: var-log-contrail
+        hostPath:
+          path: /var/log/contrail/
+{{- end }}

--- a/contrail-vrouter/values.yaml
+++ b/contrail-vrouter/values.yaml
@@ -14,9 +14,13 @@ labels:
     node_selector_value: enabled
 
 dependencies:
-  agent:
+  vrouter_agent:
     daemonset:
     - contrail-config
+  vrouter_nodemgr:
+    daemonset:
+    - contrail-config
+    - contrail-vrouter-agent
 
 conf:
   # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
@@ -49,5 +53,6 @@ endpoints:
     protocol: http
 
 manifests:
+  each_container_is_pod: true
   configmap_env: true
   daemonset_agent: true


### PR DESCRIPTION
Created a config paramter (manifests.each_container_is_pod) in values.yaml for all charts. If set it will install each of contrail service as a separate pod