### PR TITLE
Making vrouter-init-kernel work for ubuntu host OS

### DIFF
--- a/contrail-vrouter/templates/daemonset-agent-only.yaml
+++ b/contrail-vrouter/templates/daemonset-agent-only.yaml
@@ -42,6 +42,13 @@ spec:
               name: configmap-vrouter
           - configMapRef:
               name: configmap-vrouter-auth
+          volumeMounts:
+{{- if eq $host_os "ubuntu"}}
+          - mountPath: /usr/src
+            name: usr-src
+          - mountPath: /lib/modules
+            name: lib-modules
+{{- end }}
       containers:
       - name: contrail-vrouter-agent
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.agent_vrouter .Values.images.tags.contrail_version | quote }}

--- a/contrail-vrouter/templates/daemonset-agent.yaml
+++ b/contrail-vrouter/templates/daemonset-agent.yaml
@@ -43,6 +43,13 @@ spec:
               name: configmap-vrouter
           - configMapRef:
               name: configmap-vrouter-auth
+          volumeMounts:
+{{- if eq $host_os "ubuntu"}}
+          - mountPath: /usr/src
+            name: usr-src
+          - mountPath: /lib/modules
+            name: lib-modules
+{{- end }}  
       containers:
       - name: contrail-vrouter-agent
         image: {{ printf "%s/%s:%s" .Values.images.tags.registry .Values.images.tags.agent_vrouter .Values.images.tags.contrail_version | quote }}


### PR DESCRIPTION
For ubuntu host os, we are mounting usr/src & /lib/modules directory from host
to container