### PR TITLE
Adding helm-toolkit to contrail-helm-deployer repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 HELM := helm
-CONTRAIL_CHARTS := contrail-helper $(filter-out contrail-helper, $(patsubst %/Chart.yaml, %, $(wildcard */Chart.yaml)))
+FILTER_CHARTS := contrail-helper helm-toolkit
+CONTRAIL_CHARTS := $(FILTER_CHARTS) $(filter-out $(FILTER_CHARTS), $(patsubst %/Chart.yaml, %, $(wildcard */Chart.yaml)))
 BUILD_CHARTS := $(foreach chart, $(CONTRAIL_CHARTS), build-$(chart))
 
 .phony: all

--- a/contrail-analytics/requirements.yaml
+++ b/contrail-analytics/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: contrail-helper
     repository: http://localhost:8879/charts
     version: 0.1.0
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/contrail-analytics/templates/configmap-env.yaml
+++ b/contrail-analytics/templates/configmap-env.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.manifests.configmap_env }}
 {{- $context := . }}
-{{- $keystone_auth_host := tuple $context "keystone" | include "contrail-helper.get_endpoint_host" }}
-{{- $rabbitmq_host := tuple $context "rabbitmq" | include "contrail-helper.get_endpoint_host" }}
+{{- $keystone_auth_host := tuple "keystone" "internal" $context | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+{{- $rabbitmq_host := tuple "rabbitmq" "internal" $context | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
 
 ---
 apiVersion: v1
@@ -9,27 +9,25 @@ kind: ConfigMap
 metadata:
   name: configmap-analytics
 data:
-  CONTROLLER_NODES: {{ .Values.conf.controller_nodes | quote }}
-  LOG_LEVEL: {{ .Values.conf.log_level | quote }}
-  ZOOKEEPER_ANALYTICS_PORT: {{ .Values.conf.analytics_zookeeper.port | quote }}
+  {{- range $key, $value := .Values.contrail_env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-analytics-auth
 data:
-  CLOUD_ORCHESTRATOR: {{ .Values.conf.cloud_orchestrator }}
-  AAA_MODE: {{ .Values.conf.aaa_mode }}
   KEYSTONE_AUTH_ADMIN_USER: {{ .Values.endpoints.keystone.auth.username }}
   KEYSTONE_AUTH_ADMIN_TENANT: {{ .Values.endpoints.keystone.auth.project_name }}
   KEYSTONE_AUTH_ADMIN_PASSWORD: {{ .Values.endpoints.keystone.auth.password }}
   KEYSTONE_AUTH_USER_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.user_domain_name }}
   KEYSTONE_AUTH_PROJECT_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.project_domain_name }}
-  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path }}
+  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path.default }}
   KEYSTONE_AUTH_HOST: {{ $keystone_auth_host }}
-  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.protocol }}
-  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin | quote }}
-  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api | quote }}
+  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.scheme.default }}
+  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin.default | quote }}
+  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api.default | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -37,10 +35,9 @@ metadata:
   name: configmap-analytics-rabbitmq
 data:
   RABBITMQ_NODES: {{ $rabbitmq_host }}
-  RABBITMQ_PORT: {{ .Values.endpoints.rabbitmq.port.amqp | quote }}
-  RABBITMQ_USER: {{ .Values.endpoints.rabbitmq.auth.user.username | quote }}
-  RABBITMQ_PASSWORD: {{ .Values.endpoints.rabbitmq.auth.user.password | quote }}
-  RABBITMQ_USE_SSL: {{ .Values.conf.rabbitmq.use_ssl | quote }}
-
-
+  RABBITMQ_PORT: {{ .Values.endpoints.rabbitmq.port.amqp.default | quote }}
+  RABBITMQ_USER: {{ .Values.endpoints.rabbitmq.auth.username | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.endpoints.rabbitmq.auth.password | quote }}
+  RABBITMQ_USE_SSL: {{ .Values.contrail_env.RABBITMQ_USE_SSL | default "false" | quote }}
+  RABBITMQ_VHOST: {{ .Values.endpoints.rabbitmq.path | default "/" | quote }}
 {{- end }}

--- a/contrail-analytics/templates/daemonset-alarm-gen.yaml
+++ b/contrail-analytics/templates/daemonset-alarm-gen.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-alarm-gen" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-alarm-gen" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.alarm_gen | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.alarm_gen nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-alarm-gen
         image: {{ .Values.images.tags.analytics_alarm_gen | quote }}

--- a/contrail-analytics/templates/daemonset-analytics-api.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-api.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-analytics" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-analytics" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.analytics | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.analytics nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-analytics-api
         image: {{ .Values.images.tags.analytics_api | quote }}

--- a/contrail-analytics/templates/daemonset-analytics-collector.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-collector.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-collector" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-collector" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.contrail_collector | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.contrail_collector nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-collector
         image: {{ .Values.images.tags.contrail_collector | quote }}

--- a/contrail-analytics/templates/daemonset-analytics-nodemgr.yaml
+++ b/contrail-analytics/templates/daemonset-analytics-nodemgr.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-analytics-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-analytics-nodemgr" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.analytics_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.analytics_nodemgr nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-analytics-nodemgr
         image: {{ .Values.images.tags.nodemgr | quote }}

--- a/contrail-analytics/templates/daemonset-analytics.yaml
+++ b/contrail-analytics/templates/daemonset-analytics.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-analytics" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-analytics" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.analytics | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.analytics nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-analytics-api
         image: {{ .Values.images.tags.analytics_api | quote }}

--- a/contrail-analytics/templates/daemonset-query-engine.yaml
+++ b/contrail-analytics/templates/daemonset-query-engine.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-query-engine" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-query-engine" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.query_engine | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.query_engine nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-query-engine
         image: {{ .Values.images.tags.analytics_query_engine | quote }}

--- a/contrail-analytics/templates/daemonset-snmp-collector.yaml
+++ b/contrail-analytics/templates/daemonset-snmp-collector.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-snmp-collector" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-snmp-collector" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.snmp_collector | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.snmp_collector nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-snmp-collector
         image: {{ .Values.images.tags.analytics_snmp_collector | quote }}

--- a/contrail-analytics/templates/daemonset-topology.yaml
+++ b/contrail-analytics/templates/daemonset-topology.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-topology" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-topology" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.contrail_topology | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.contrail_topology nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-topology
         image: {{ .Values.images.tags.contrail_topology | quote }}

--- a/contrail-analytics/values.yaml
+++ b/contrail-analytics/values.yaml
@@ -60,40 +60,30 @@ dependencies:
     daemonset:
     - contrail-analytics
 
-conf:
-  # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
-  host_os: ubuntu
-  controller_nodes: 10.87.65.248
-  log_level: SYS_NOTICE
-
-  cloud_orchestrator: openstack
-  aaa_mode: cloud-admin
-
-  rabbitmq:
-    use_ssl: False
-
-  analytics_zookeeper:
-    port: 2181
+contrail_env:
+  CONTROLLER_NODES: 10.87.65.248
+  LOG_LEVEL: SYS_NOTICE
+  CLOUD_ORCHESTRATOR: openstack
+  AAA_MODE: cloud-admin
 
 # typically overriden by environmental
 # values, but should include all endpoints
 # required by this chart
 endpoints:
-  # TO-DO
-  cluster_domain: svc.cluster.local
+  cluster_domain_suffix: cluster.local
   rabbitmq:
     auth:
-      admin:
-        username: admin
-        password: password
-      user:
-        username: rabbitmq
-        password: password
+      username: rabbitmq
+      password: password
     path: /
-    host: rabbit
+    scheme: rabbit
     port:
-      amqp: 5672
-    namespace: openstack
+      amqp:
+        default: 5672
+    hosts:
+      default: rabbitmq
+    host_fqdn_override:
+       default: null
     domain_override: null
   keystone:
     auth:
@@ -102,13 +92,19 @@ endpoints:
       project_name: admin
       user_domain_name: default
       project_domain_name: default
-    host: keystone-api
-    namespace: openstack
-    path: /v3
+    hosts:
+      default: keystone-api
+    path:
+      default: /v3
     port:
-      admin: 35357
-      api: 80
-    protocol: http
+      admin:
+        default: 35357
+      api:
+        default: 80
+    scheme:
+      default: http
+    host_fqdn_override:
+       default: null
 
 manifests:
   each_container_is_pod: true

--- a/contrail-controller/requirements.yaml
+++ b/contrail-controller/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: contrail-helper
     repository: http://localhost:8879/charts
     version: 0.1.0
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/contrail-controller/templates/configmap-env.yaml
+++ b/contrail-controller/templates/configmap-env.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.manifests.configmap_env }}
 {{- $context := . }}
-{{- $keystone_auth_host := tuple $context "keystone" | include "contrail-helper.get_endpoint_host" }}
-{{- $rabbitmq_host := tuple $context "rabbitmq" | include "contrail-helper.get_endpoint_host" }}
+{{- $keystone_auth_host := tuple "keystone" "internal" $context | include "helm-toolkit.endpoints.hostname_namespaced_endpoint_lookup" }}
+{{- $rabbitmq_host := tuple "rabbitmq" "internal" $context | include "helm-toolkit.endpoints.hostname_namespaced_endpoint_lookup" }}
 
 ---
 apiVersion: v1
@@ -9,27 +9,26 @@ kind: ConfigMap
 metadata:
   name: configmap-controller
 data:
-  CONTROLLER_NODES: {{ .Values.conf.controller_nodes }}
-  LOG_LEVEL: {{ .Values.conf.log_level }}
-  CONFIG_API_PORT: "8082"
+  {{- range $key, $value := .Values.contrail_env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-controller-auth
 data:
-  CLOUD_ORCHESTRATOR: {{ .Values.conf.cloud_orchestrator }}
-  AAA_MODE: {{ .Values.conf.aaa_mode }}
   KEYSTONE_AUTH_ADMIN_USER: {{ .Values.endpoints.keystone.auth.username }}
   KEYSTONE_AUTH_ADMIN_TENANT: {{ .Values.endpoints.keystone.auth.project_name }}
   KEYSTONE_AUTH_ADMIN_PASSWORD: {{ .Values.endpoints.keystone.auth.password }}
   KEYSTONE_AUTH_USER_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.user_domain_name }}
   KEYSTONE_AUTH_PROJECT_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.project_domain_name }}
-  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path }}
+  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path.default }}
   KEYSTONE_AUTH_HOST: {{ $keystone_auth_host }}
-  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.protocol }}
-  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin | quote }}
-  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api | quote }}
+  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.scheme.default }}
+  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin.default | quote }}
+  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api.default | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -37,9 +36,10 @@ metadata:
   name: configmap-controller-rabbitmq
 data:
   RABBITMQ_NODES: {{ $rabbitmq_host }}
-  RABBITMQ_PORT: {{ .Values.endpoints.rabbitmq.port.amqp | quote }}
-  RABBITMQ_USER: {{ .Values.endpoints.rabbitmq.auth.user.username | quote }}
-  RABBITMQ_PASSWORD: {{ .Values.endpoints.rabbitmq.auth.user.password | quote }}
-  RABBITMQ_USE_SSL: {{ .Values.conf.rabbitmq.use_ssl | quote }}
+  RABBITMQ_PORT: {{ .Values.endpoints.rabbitmq.port.amqp.default | quote }}
+  RABBITMQ_USER: {{ .Values.endpoints.rabbitmq.auth.username | quote }}
+  RABBITMQ_PASSWORD: {{ .Values.endpoints.rabbitmq.auth.password | quote }}
+  RABBITMQ_USE_SSL: {{ .Values.contrail_env.RABBITMQ_USE_SSL | default "false" | quote }}
+  RABBITMQ_VHOST: {{ .Values.endpoints.rabbitmq.path | default "/" | quote }}
 
 {{- end }}

--- a/contrail-controller/templates/daemonset-config-api.yaml
+++ b/contrail-controller/templates/daemonset-config-api.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-config-api" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-config-api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.config | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.config nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-config-api
         image: {{ .Values.images.tags.config_api | quote }}

--- a/contrail-controller/templates/daemonset-config-nodemgr.yaml
+++ b/contrail-controller/templates/daemonset-config-nodemgr.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-config-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-config-nodemgr" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.config_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.config_nodemgr nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-config-nodemgr
         image: {{ .Values.images.tags.nodemgr | quote }}

--- a/contrail-controller/templates/daemonset-config.yaml
+++ b/contrail-controller/templates/daemonset-config.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-config" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-config" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.config | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.config nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-config-api
         image: {{ .Values.images.tags.config_api | quote }}

--- a/contrail-controller/templates/daemonset-control-nodemgr.yaml
+++ b/contrail-controller/templates/daemonset-control-nodemgr.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-nodemgr" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.control_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.control_nodemgr nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-control-nodemgr
         image: {{ .Values.images.tags.nodemgr | quote }}

--- a/contrail-controller/templates/daemonset-control-only.yaml
+++ b/contrail-controller/templates/daemonset-control-only.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-control" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-control" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.control | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.control nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-control
         image: {{ .Values.images.tags.contrail_control | quote }}

--- a/contrail-controller/templates/daemonset-control.yaml
+++ b/contrail-controller/templates/daemonset-control.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-control" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-control" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.control | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.control nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-control
         image: {{ .Values.images.tags.contrail_control | quote }}

--- a/contrail-controller/templates/daemonset-devicemgr.yaml
+++ b/contrail-controller/templates/daemonset-devicemgr.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-devicemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-devicemgr" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.devicemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.devicemgr nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-devicemgr
         image: {{ .Values.images.tags.config_devicemgr | quote }}

--- a/contrail-controller/templates/daemonset-dns.yaml
+++ b/contrail-controller/templates/daemonset-dns.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-dns" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-dns" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.contrail_dns | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.contrail_dns nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-dns
         image: {{ .Values.images.tags.control_dns | quote }}

--- a/contrail-controller/templates/daemonset-named.yaml
+++ b/contrail-controller/templates/daemonset-named.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-named" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-named" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.contrail_named | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.contrail_named nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-named
         image: {{ .Values.images.tags.control_named | quote }}

--- a/contrail-controller/templates/daemonset-schema-transformer.yaml
+++ b/contrail-controller/templates/daemonset-schema-transformer.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-schema-transformer" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-schema-transformer" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.schema_transformer | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.schema_transformer nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-schema-transformer
         image: {{ .Values.images.tags.config_schema_transformer | quote }}

--- a/contrail-controller/templates/daemonset-svcmonitor.yaml
+++ b/contrail-controller/templates/daemonset-svcmonitor.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-svcmonitor" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-svcmonitor" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.svcmonitor | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.svcmonitor nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-svc-monitor
         image: {{ .Values.images.tags.config_svcmonitor | quote }}

--- a/contrail-controller/templates/daemonset-web.yaml
+++ b/contrail-controller/templates/daemonset-web.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-webui" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-webui" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -28,7 +28,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.webui | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.webui nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-webui-middleware
         image: {{ .Values.images.tags.webui_middleware | quote }}

--- a/contrail-controller/templates/daemonset-webui-middleware.yaml
+++ b/contrail-controller/templates/daemonset-webui-middleware.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-webui-middleware" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-webui-middleware" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.webui_middleware | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.webui_middleware nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-webui-middleware
         image: {{ .Values.images.tags.webui_middleware | quote }}

--- a/contrail-controller/templates/daemonset-webui.yaml
+++ b/contrail-controller/templates/daemonset-webui.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-webui" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-webui" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.webui | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.webui nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-webui
         image: {{ .Values.images.tags.webui | quote }}

--- a/contrail-controller/values.yaml
+++ b/contrail-controller/values.yaml
@@ -91,37 +91,31 @@ dependencies:
     - contrail-config
     - contrail-webui
 
-conf:
-  # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
-  host_os: ubuntu
-  controller_nodes: 10.87.65.248
-  log_level: SYS_NOTICE
+contrail_env:
+  CONTROLLER_NODES: 10.87.65.248
+  LOG_LEVEL: SYS_NOTICE
+  CLOUD_ORCHESTRATOR: openstack
+  AAA_MODE: cloud-admin
 
-  cloud_orchestrator: openstack
-  aaa_mode: cloud-admin
-
-  rabbitmq:
-    use_ssl: False
 
 # typically overriden by environmental
 # values, but should include all endpoints
 # required by this chart
 endpoints:
-  # TO-DO
-  cluster_domain: svc.cluster.local
+  cluster_domain_suffix: cluster.local
   rabbitmq:
     auth:
-      admin:
-        username: admin
-        password: password
-      user:
-        username: rabbitmq
-        password: password
+      username: rabbitmq
+      password: password
     path: /
-    host: rabbitmq
+    scheme: rabbit
     port:
-      amqp: 5672
-    namespace: openstack
+      amqp:
+        default: 5672
+    hosts:
+      default: rabbitmq
+    host_fqdn_override:
+       default: null
     domain_override: null
   keystone:
     auth:
@@ -130,13 +124,19 @@ endpoints:
       project_name: admin
       user_domain_name: default
       project_domain_name: default
-    host: keystone-api
-    namespace: openstack
-    path: /v3
+    hosts:
+      default: keystone-api
+    path:
+      default: /v3
     port:
-      admin: 35357
-      api: 80
-    protocol: http
+      admin:
+        default: 35357
+      api:
+        default: 80
+    scheme:
+      default: http
+    host_fqdn_override:
+       default: null
 
 manifests:
   each_container_is_pod: true

--- a/contrail-thirdparty/requirements.yaml
+++ b/contrail-thirdparty/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: contrail-helper
     repository: http://localhost:8879/charts
     version: 0.1.0
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/contrail-thirdparty/templates/configmap-env.yaml
+++ b/contrail-thirdparty/templates/configmap-env.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.manifests.configmap_env }}
 {{- $context := . }}
-{{- $controller_nodes := .Values.conf.controller_nodes }}
+{{- $config_nodes := .Values.contrail_env.CONFIG_NODES | default .Values.contrail_env.CONTROLLER_NODES }}
+{{- $analytics_nodes := .Values.contrail_env.ANALYTICS_NODES | default .Values.contrail_env.CONTROLLER_NODES }}
 
 ---
 apiVersion: v1
@@ -8,7 +9,7 @@ kind: ConfigMap
 metadata:
   name: contrail-analytics-zookeeper
 data:
-  ZOO_PORT: {{ .Values.conf.analytics_zookeeper.port | default 2182 | quote }}
+  ZOO_PORT: {{ .Values.contrail_env.ZOOKEEPER_ANALYTICS_PORT | default 2182 | quote }}
 
 ---
 apiVersion: v1
@@ -16,7 +17,7 @@ kind: ConfigMap
 metadata:
   name: contrail-config-zookeeper
 data:
-  ZOO_PORT: {{ .Values.conf.config_zookeeper.port | default 2181 | quote }}
+  ZOO_PORT: {{ .Values.contrail_env.ZOOKEEPER_PORT | default 2181 | quote }}
 
 ---
 apiVersion: v1
@@ -24,11 +25,9 @@ kind: ConfigMap
 metadata:
   name: contrail-thirdparty
 data:
-  CONTROLLER_NODES: {{ $controller_nodes }}
-  KAFKA_NODES: {{ .Values.conf.kafka_nodes | default "" }}
-  ZOOKEEPER_NODES: {{ .Values.conf.analyticsdb_nodes | default "" }}
-  ZOOKEEPER_ANALYTICS_PORT: {{ .Values.conf.analytics_zookeeper.port | default 2182 | quote}}
-  LOG_LEVEL: {{ .Values.conf.log_level }}
+  {{- range $key, $value := .Values.contrail_env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 
 ---
 apiVersion: v1
@@ -37,13 +36,13 @@ metadata:
   name: contrail-configdb
 data:
   # TODO: fix seeds and listen address
-  CASSANDRA_SEEDS: {{ .Values.conf.configdb_nodes | default $controller_nodes }}
+  CASSANDRA_SEEDS: {{ .Values.contrail_env.CONFIGDB_NODES | default $config_nodes | quote }}
+  CASSANDRA_LISTEN_ADDRESS: {{ .Values.contrail_env.CONFIGDB_NODES | default $config_nodes | quote }}
   CASSANDRA_CLUSTER_NAME: ContrailConfigDB
   CASSANDRA_START_RPC: "true"
-  CASSANDRA_LISTEN_ADDRESS: {{ .Values.conf.configdb_nodes | default $controller_nodes }}
   JVM_EXTRA_OPTS: >-
-    -Dcassandra.rpc_port={{ .Values.conf.configdb.rpc_port }}
-    -Dcassandra.native_transport_port={{ .Values.conf.configdb.cql_port }}
+    -Dcassandra.rpc_port={{ .Values.contrail_env.CONFIGDB_PORT | default 9161 }}
+    -Dcassandra.native_transport_port={{ .Values.contrail_env.CONFIGDB_CQL_PORT | default 9041 }}
     -Dcassandra.ssl_storage_port=7011
     -Dcassandra.storage_port=7010
     -Dcassandra.jmx.local.port=7200
@@ -55,17 +54,16 @@ kind: ConfigMap
 metadata:
   name: contrail-analyticsdb
 data:
-  # TODO: fix seeds and listen address
-  CASSANDRA_SEEDS: {{ .Values.conf.analyticsdb_nodes | default $controller_nodes | quote }}
-  CASSANDRA_CLUSTER_NAME: Contrail
+  CASSANDRA_SEEDS: {{ .Values.contrail_env.ANALYTICSDB_NODES | default $analytics_nodes | quote }}
+  CASSANDRA_LISTEN_ADDRESS: {{ .Values.contrail_env.ANALYTICSDB_NODES | default $analytics_nodes | quote }}
+  CASSANDRA_CLUSTER_NAME: ContrailAnalyticsDB
   CASSANDRA_START_RPC: "true"
-  CASSANDRA_LISTEN_ADDRESS: {{ .Values.conf.analyticsdb_nodes | default $controller_nodes | quote }}
   JVM_EXTRA_OPTS: >-
-    -Dcassandra.rpc_port={{ .Values.conf.analyticsdb.rpc_port }}
-    -Dcassandra.native_transport_port={{ .Values.conf.analyticsdb.cql_port }}
+    -Dcassandra.rpc_port={{ .Values.contrail_env.ANALYTICSDB_PORT | default 9160 }}
+    -Dcassandra.native_transport_port={{ .Values.contrail_env.ANALYTICSDB_CQL_PORT | default 9042}}
     -Dcassandra.ssl_storage_port=7001
     -Dcassandra.storage_port=7000
+    -Dcassandra.jmx.local.port=7100
     -Xms2G -Xmx2G
 
----
 {{- end }}

--- a/contrail-thirdparty/templates/daemonset-analytics-zookeeper.yaml
+++ b/contrail-thirdparty/templates/daemonset-analytics-zookeeper.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "analytics-zookeeper" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "analytics-zookeeper" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.analytics_zookeeper | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.analytics_zookeeper nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: zookeeper
         image: {{ .Values.images.tags.zookeeper | quote }}

--- a/contrail-thirdparty/templates/daemonset-analyticsdb.yaml
+++ b/contrail-thirdparty/templates/daemonset-analyticsdb.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-analyticsdb" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-analyticsdb" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.analyticsdb | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.analyticsdb nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-analyticsdb
         image: {{ .Values.images.tags.cassandra | quote }}

--- a/contrail-thirdparty/templates/daemonset-config-zookeeper.yaml
+++ b/contrail-thirdparty/templates/daemonset-config-zookeeper.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "config-zookeeper" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "config-zookeeper" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.config_zookeeper | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.config_zookeeper nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: zookeeper
         image: {{ .Values.images.tags.zookeeper | quote }}

--- a/contrail-thirdparty/templates/daemonset-configdb.yaml
+++ b/contrail-thirdparty/templates/daemonset-configdb.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-configdb" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-configdb" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.configdb | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.configdb nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-configdb
         image: {{ .Values.images.tags.cassandra | quote }}

--- a/contrail-thirdparty/templates/daemonset-kafka.yaml
+++ b/contrail-thirdparty/templates/daemonset-kafka.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "kafka" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "kafka" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.kafka | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.kafka nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: kafka
         image: {{ .Values.images.tags.kafka | quote }}

--- a/contrail-thirdparty/templates/daemonset-redis.yaml
+++ b/contrail-thirdparty/templates/daemonset-redis.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "redis" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "redis" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       affinity:
         nodeAffinity:
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.redis | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.redis nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: redis
         image: {{ .Values.images.tags.redis | quote }}

--- a/contrail-thirdparty/values.yaml
+++ b/contrail-thirdparty/values.yaml
@@ -37,40 +37,13 @@ dependencies:
   configdb:
     daemonset:
     - contrail-config-zookeeper
-  redis: {}
-  analytics_zookeeper: {}
-  config_zookeeper: {}
 
 
-conf:
-  # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
-  host_os: ubuntu
-  controller_nodes: 10.87.65.248
-  log_level: SYS_NOTICE
-
-  cloud_orchestrator: openstack
-  aaa_mode: cloud-admin
-
-  configdb:
-    rpc_port: 9161
-    cql_port: 9041
-
-  analyticsdb:
-    rpc_port: 9160
-    cql_port: 9042
-
-  config_zookeeper:
-    port: 2181
-
-  analytics_zookeeper:
-    port: 2182
-
-# typically overriden by environmental
-# values, but should include all endpoints
-# required by this chart
-endpoints:
-  # TO-DO
-  default: null
+contrail_env:
+  CONTROLLER_NODES: 10.87.65.248
+  LOG_LEVEL: SYS_NOTICE
+  CLOUD_ORCHESTRATOR: openstack
+  AAA_MODE: cloud-admin
 
 manifests:
   configmap_env: true

--- a/contrail-vrouter/requirements.yaml
+++ b/contrail-vrouter/requirements.yaml
@@ -2,3 +2,6 @@ dependencies:
   - name: contrail-helper
     repository: http://localhost:8879/charts
     version: 0.1.0
+  - name: helm-toolkit
+    repository: http://localhost:8879/charts
+    version: 0.1.0

--- a/contrail-vrouter/templates/configmap-env.yaml
+++ b/contrail-vrouter/templates/configmap-env.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.manifests.configmap_env }}
 {{- $context := . }}
-{{- $keystone_auth_host := tuple $context "keystone" | include "contrail-helper.get_endpoint_host" }}
+{{- $keystone_auth_host := tuple "keystone" "internal" $context | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
 
 ---
 apiVersion: v1
@@ -8,25 +8,23 @@ kind: ConfigMap
 metadata:
   name: configmap-vrouter
 data:
-  CONTROLLER_NODES: {{ .Values.conf.controller_nodes }}
-  LOG_LEVEL: {{ .Values.conf.log_level }}
+  {{- range $key, $value := .Values.contrail_env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-vrouter-auth
 data:
-  CLOUD_ORCHESTRATOR: {{ .Values.conf.cloud_orchestrator }}
-  AAA_MODE: {{ .Values.conf.aaa_mode }}
   KEYSTONE_AUTH_ADMIN_USER: {{ .Values.endpoints.keystone.auth.username }}
   KEYSTONE_AUTH_ADMIN_TENANT: {{ .Values.endpoints.keystone.auth.project_name }}
   KEYSTONE_AUTH_ADMIN_PASSWORD: {{ .Values.endpoints.keystone.auth.password }}
   KEYSTONE_AUTH_USER_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.user_domain_name }}
   KEYSTONE_AUTH_PROJECT_DOMAIN_NAME: {{ .Values.endpoints.keystone.auth.project_domain_name }}
-  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path }}
+  KEYSTONE_AUTH_URL_VERSION: {{ .Values.endpoints.keystone.path.default }}
   KEYSTONE_AUTH_HOST: {{ $keystone_auth_host }}
-  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.protocol }}
-  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin | quote }}
-  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api | quote }}
-
+  KEYSTONE_AUTH_PROTO: {{ .Values.endpoints.keystone.scheme.default }}
+  KEYSTONE_AUTH_ADMIN_PORT: {{ .Values.endpoints.keystone.port.admin.default | quote }}
+  KEYSTONE_AUTH_PUBLIC_PORT: {{ .Values.endpoints.keystone.port.api.default | quote }}
 {{- end }}

--- a/contrail-vrouter/templates/daemonset-agent-only.yaml
+++ b/contrail-vrouter/templates/daemonset-agent-only.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-vrouter-agent" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-vrouter-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       #Disable affinity for single node setup
       affinity:
@@ -32,7 +32,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.vrouter_agent | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.vrouter_agent nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: contrail-agent-init-kernel
           image: {{ .Values.images.tags.agent_vrouter_init_kernel | quote }}
           imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}

--- a/contrail-vrouter/templates/daemonset-agent-only.yaml
+++ b/contrail-vrouter/templates/daemonset-agent-only.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_agent }}
 {{- $context := . }}
 # host_os is a mandatory field
-{{- $_ := required ".Values.conf.host_os must be specified, valid values are ubuntu, centos" .Values.conf.host_os }}
-{{- $host_os := .Values.conf.host_os }}
+{{- $_ := required ".Values.node.host_os must be specified, valid values are ubuntu, centos" .Values.node.host_os }}
+{{- $host_os := .Values.node.host_os }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/contrail-vrouter/templates/daemonset-agent.yaml
+++ b/contrail-vrouter/templates/daemonset-agent.yaml
@@ -2,8 +2,8 @@
 {{- if .Values.manifests.daemonset_agent }}
 {{- $context := . }}
 # host_os is a mandatory field
-{{- $_ := required ".Values.conf.host_os must be specified, valid values are ubuntu, centos" .Values.conf.host_os }}
-{{- $host_os := .Values.conf.host_os }}
+{{- $_ := required ".Values.node.host_os must be specified, valid values are ubuntu, centos" .Values.node.host_os }}
+{{- $host_os := .Values.node.host_os }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/contrail-vrouter/templates/daemonset-agent.yaml
+++ b/contrail-vrouter/templates/daemonset-agent.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-agent" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-agent" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       #Disable affinity for single node setup
       affinity:
@@ -33,7 +33,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.agent | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.agent nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: contrail-agent-init-kernel
           image: {{ .Values.images.tags.agent_vrouter_init_kernel | quote }}
           imagePullPolicy: {{ default "" .Values.images.imagePullPolicy | quote }}

--- a/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
+++ b/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-{{ tuple $context "opencontrail" "contrail-vrouter-nodemgr" | include "contrail-helper.kubernetes_spec.get_metadata_label" | indent 8 }}
+{{ tuple $context "opencontrail" "contrail-vrouter-nodemgr" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
     spec:
       #Disable affinity for single node setup
       affinity:
@@ -32,7 +32,7 @@ spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       initContainers:
-{{ tuple $context .Values.dependencies.vrouter_nodemgr | include "contrail-helper.kubernetes_spec.get_entrypoint_init_container" | indent 8 }}
+{{ tuple $context .Values.dependencies.vrouter_nodemgr nil | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
       containers:
       - name: contrail-agent-nodemgr
         image: {{ .Values.images.tags.nodemgr | quote }}

--- a/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
+++ b/contrail-vrouter/templates/daemonset-vrouter-nodemgr.yaml
@@ -1,8 +1,5 @@
 {{- if and .Values.manifests.each_container_is_pod .Values.manifests.daemonset_agent }}
 {{- $context := . }}
-# host_os is a mandatory field
-{{- $_ := required ".Values.conf.host_os must be specified, valid values are ubuntu, centos" .Values.conf.host_os }}
-{{- $host_os := .Values.conf.host_os }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/contrail-vrouter/values.yaml
+++ b/contrail-vrouter/values.yaml
@@ -23,21 +23,20 @@ dependencies:
     - contrail-config
     - contrail-vrouter-agent
 
-conf:
-  # host_os - (OPTIONAL) host operating system release. Sample values "ubuntu" and "centos". Default is ubuntu
-  host_os: centos
-  controller_nodes: 10.87.65.248
-  log_level: SYS_NOTICE
+contrail_env:
+  CONTROLLER_NODES: 10.87.65.248
+  LOG_LEVEL: SYS_NOTICE
+  CLOUD_ORCHESTRATOR: openstack
+  AAA_MODE: cloud-admin
 
-  cloud_orchestrator: openstack
-  aaa_mode: cloud-admin
+node:
+  host_os: ubuntu
 
 # typically overriden by environmental
 # values, but should include all endpoints
 # required by this chart
 endpoints:
-  # TO-DO
-  cluster_domain: svc.cluster.local
+  cluster_domain_suffix: cluster.local
   keystone:
     auth:
       username: admin
@@ -45,13 +44,19 @@ endpoints:
       project_name: admin
       user_domain_name: default
       project_domain_name: default
-    host: keystone-api
-    namespace: openstack
-    path: /v3
+    hosts:
+      default: keystone-api
+    path:
+      default: /v3
     port:
-      admin: 35357
-      api: 80
-    protocol: http
+      admin:
+        default: 35357
+      api:
+        default: 80
+    scheme:
+      default: http
+    host_fqdn_override:
+       default: null
 
 manifests:
   each_container_is_pod: true

--- a/doc/openstack-helm-aio-install.md
+++ b/doc/openstack-helm-aio-install.md
@@ -92,21 +92,21 @@ Using below step you can bring an all-in-one cluster with openstack and contrail
   kubectl replace -f ${OSH_PATH}/tools/kubeadm-aio/assets/opt/rbac/dev.yaml
 
   helm install --name contrail-thirdparty ${CHD_PATH}/contrail-thirdparty \
-  --namespace=openstack --set conf.controller_nodes=${CONTROLLER_NODE} \
+  --namespace=openstack --set contrail_env.CONTROLLER_NODES=${CONTROLLER_NODE} \
   --set manifests.each_container_is_pod=true
 
   helm install --name contrail-controller ${CHD_PATH}/contrail-controller \
-  --namespace=openstack --set conf.controller_nodes=${CONTROLLER_NODE} \
+  --namespace=openstack --set contrail_env.CONTROLLER_NODES=${CONTROLLER_NODE} \
   --set manifests.each_container_is_pod=true
 
   helm install --name contrail-analytics ${CHD_PATH}/contrail-analytics \
-  --namespace=openstack --set conf.controller_nodes=${CONTROLLER_NODE} \
+  --namespace=openstack --set contrail_env.CONTROLLER_NODES=${CONTROLLER_NODE} \
   --set manifests.each_container_is_pod=true
 
   # Edit contrail-vrouter/values.yaml and make sure that images.tags.agent_vrouter_init_kernel is right. Image tag name will be different depending upon your linux. Also set the conf.host_os to ubuntu or centos depending on your system
 
   helm install --name contrail-vrouter ${CHD_PATH}/contrail-vrouter \
-  --namespace=openstack --set conf.controller_nodes=${CONTROLLER_NODE} \
+  --namespace=openstack --set contrail_env.CONTROLLER_NODES=${CONTROLLER_NODE} \
   --set manifests.each_container_is_pod=true
 
   ```

--- a/helm-toolkit/.gitignore
+++ b/helm-toolkit/.gitignore
@@ -1,0 +1,3 @@
+secrets/*
+!secrets/.gitkeep 
+templates/_secrets.tpl

--- a/helm-toolkit/.helmignore
+++ b/helm-toolkit/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+
+bin/
+etc/
+patches/
+*.py
+Makefile

--- a/helm-toolkit/Chart.yaml
+++ b/helm-toolkit/Chart.yaml
@@ -1,0 +1,18 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+description: OpenStack-Helm Helm-Toolkit
+name: helm-toolkit
+version: 0.1.0

--- a/helm-toolkit/Makefile
+++ b/helm-toolkit/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+EXCLUDE := templates/* charts/* Chart.yaml requirement* values.yaml Makefile utils/* helm-toolkit/Chart.yaml
+SECRETS := $(shell find secrets -type f $(foreach e,$(EXCLUDE), -not -path "$(e)") )
+
+templates/_secrets.tpl: Makefile $(SECRETS)
+	echo Generating $(CURDIR)/$@
+	rm -f $@
+	for i in $(SECRETS); do  printf '{{ define "'$$i'" }}' >> $@; cat $$i >> $@; printf "{{ end }}\n" >> $@; done

--- a/helm-toolkit/requirements.yaml
+++ b/helm-toolkit/requirements.yaml
@@ -1,0 +1,15 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dependencies: []

--- a/helm-toolkit/templates/endpoints/_authenticated_endpoint_uri_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_authenticated_endpoint_uri_lookup.tpl
@@ -1,0 +1,48 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function helps resolve database style endpoints:
+#
+# Presuming that .Values contains an endpoint: definition for 'neutron-db' with the
+# appropriate attributes, a call such as:
+# { tuple "neutron-db" "internal" "userClass" "portName" . | include "helm-toolkit.endpoints.authenticated_endpoint_uri_lookup" }
+# where portName is optional if a default port has been defined in .Values
+# returns: mysql+pymysql://username:password@internal_host:3306/dbname
+
+{{- define "helm-toolkit.endpoints.authenticated_endpoint_uri_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $userclass := index . 2 -}}
+{{- $port := index . 3 -}}
+{{- $context := index . 4 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- $userMap := index $endpointMap.auth $userclass }}
+{{- $clusterSuffix := printf "%s.%s" "svc" $context.Values.endpoints.cluster_domain_suffix }}
+{{- with $endpointMap -}}
+{{- $namespace := .namespace | default $context.Release.Namespace }}
+{{- $endpointScheme := .scheme }}
+{{- $endpointUser := index $userMap "username" }}
+{{- $endpointPass := index $userMap "password" }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default}}
+{{- $endpointPortMAP := index .port $port }}
+{{- $endpointPort := index $endpointPortMAP $endpoint | default (index $endpointPortMAP "default") }}
+{{- $endpointPath := .path | default "" }}
+{{- $endpointClusterHostname := printf "%s.%s.%s" $endpointHost $namespace $clusterSuffix }}
+{{- $endpointHostname := index .host_fqdn_override $endpoint | default .host_fqdn_override.default | default $endpointClusterHostname }}
+{{- printf "%s://%s:%s@%s:%1.f%s" $endpointScheme $endpointUser $endpointPass $endpointHostname $endpointPort $endpointPath -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_endpoint_port_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_endpoint_port_lookup.tpl
@@ -1,0 +1,37 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns hostnames from endpoint definitions for use cases
+# where the uri style return is not appropriate, and only the hostname
+# portion is used or relevant in the template:
+# { tuple "memcache" "internal" "portName" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }
+# returns: internal_host:port
+#
+# Output that requires the port aspect striped could simply split the output based on ':'
+
+{{- define "helm-toolkit.endpoints.endpoint_port_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $port := index . 2 -}}
+{{- $context := index . 3 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $endpointPortMAP := index .port $port }}
+{{- $endpointPort := index $endpointPortMAP $endpoint | default (index $endpointPortMAP "default") }}
+{{- printf "%1.f" $endpointPort -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_host_and_port_endpoint_uri_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_host_and_port_endpoint_uri_lookup.tpl
@@ -1,0 +1,43 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns hostnames from endpoint definitions for use cases
+# where the uri style return is not appropriate, and only the hostname
+# portion is used or relevant in the template:
+# { tuple "memcache" "internal" "portName" . | include "helm-toolkit.endpoints.host_and_port_endpoint_uri_lookup" }
+# returns: internal_host:port
+#
+# Output that requires the port aspect striped could simply split the output based on ':'
+
+{{- define "helm-toolkit.endpoints.host_and_port_endpoint_uri_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $port := index . 2 -}}
+{{- $context := index . 3 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $clusterSuffix := printf "%s.%s" "svc" $context.Values.endpoints.cluster_domain_suffix }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $namespace := .namespace | default $context.Release.Namespace }}
+{{- $endpointScheme := .scheme }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default }}
+{{- $endpointPortMAP := index .port $port }}
+{{- $endpointPort := index $endpointPortMAP $endpoint | default (index $endpointPortMAP "default") }}
+{{- $endpointClusterHostname := printf "%s.%s.%s" $endpointHost $namespace $clusterSuffix }}
+{{- $endpointHostname := index .host_fqdn_override $endpoint | default .host_fqdn_override.default | default $endpointClusterHostname }}
+{{- printf "%s:%1.f" $endpointHostname $endpointPort -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_hostname_fqdn_endpoint_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_hostname_fqdn_endpoint_lookup.tpl
@@ -1,0 +1,38 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns hostnames from endpoint definitions for use cases
+# where the uri style return is not appropriate, and only the hostname
+# portion is used or relevant in the template:
+# { tuple "memcache" "internal" . | include "helm-toolkit.endpoints.hostname_fqdn_endpoint_lookup" }
+# returns: internal_host_fqdn
+
+{{- define "helm-toolkit.endpoints.hostname_fqdn_endpoint_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $clusterSuffix := printf "%s.%s" "svc" $context.Values.endpoints.cluster_domain_suffix }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $namespace := .namespace | default $context.Release.Namespace }}
+{{- $endpointScheme := .scheme }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default }}
+{{- $endpointClusterHostname := printf "%s.%s.%s" $endpointHost $namespace $clusterSuffix }}
+{{- $endpointHostname := index .host_fqdn_override $endpoint | default .host_fqdn_override.default | default $endpointClusterHostname }}
+{{- printf "%s" $endpointHostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_hostname_namespaced_endpoint_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_hostname_namespaced_endpoint_lookup.tpl
@@ -1,0 +1,37 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns hostnames from endpoint definitions for use cases
+# where the uri style return is not appropriate, and only the hostname
+# portion is used or relevant in the template:
+# { tuple "memcache" "internal" . | include "helm-toolkit.endpoints.hostname_namespaced_endpoint_lookup" }
+# returns: internal_host_namespaced
+
+{{- define "helm-toolkit.endpoints.hostname_namespaced_endpoint_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $namespace := .namespace | default $context.Release.Namespace }}
+{{- $endpointScheme := .scheme }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default }}
+{{- $endpointClusterHostname := printf "%s.%s" $endpointHost $namespace }}
+{{- $endpointHostname := index .host_fqdn_override $endpoint | default .host_fqdn_override.default | default $endpointClusterHostname }}
+{{- printf "%s" $endpointHostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_hostname_short_endpoint_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_hostname_short_endpoint_lookup.tpl
@@ -1,0 +1,35 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns hostnames from endpoint definitions for use cases
+# where the uri style return is not appropriate, and only the short hostname or
+# kubernetes servicename is used or relevant in the template:
+# { tuple "memcache" "internal" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }
+# returns: the short internal hostname, which will also match the service name
+
+{{- define "helm-toolkit.endpoints.hostname_short_endpoint_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $endpointScheme := .scheme }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default}}
+{{- $endpointHostname := printf "%s" $endpointHost }}
+{{- printf "%s" $endpointHostname -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_keystone_endpoint_name_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_keystone_endpoint_name_lookup.tpl
@@ -1,0 +1,29 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function is used in endpoint management templates
+# it returns the service type for an openstack service eg:
+# { tuple orchestration . | include "keystone_endpoint_name_lookup" }
+# will return "heat"
+
+{{- define "helm-toolkit.endpoints.keystone_endpoint_name_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- $endpointName := index $endpointMap "name" }}
+{{- $endpointName | quote -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_keystone_endpoint_path_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_keystone_endpoint_path_lookup.tpl
@@ -1,0 +1,33 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns the path for a service, it takes an tuple
+# input in the form: service-type, endpoint-class, port-name. eg:
+# { tuple "orchestration" "public" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_path_lookup" }
+# will return the appropriate path.
+
+{{- define "helm-toolkit.endpoints.keystone_endpoint_path_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $port := index . 2 -}}
+{{- $context := index . 3 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $endpointPath := index .path $endpoint | default .path.default | default "/" }}
+{{- printf "%s" $endpointPath -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_keystone_endpoint_uri_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_keystone_endpoint_uri_lookup.tpl
@@ -1,0 +1,41 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns the endpoint uri for a service, it takes an tuple
+# input in the form: service-type, endpoint-class, port-name. eg:
+# { tuple "orchestration" "public" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" }
+# will return the appropriate URI.
+
+{{- define "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $port := index . 2 -}}
+{{- $context := index . 3 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $clusterSuffix := printf "%s.%s" "svc" $context.Values.endpoints.cluster_domain_suffix }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $namespace := $endpointMap.namespace | default $context.Release.Namespace }}
+{{- $endpointScheme :=  index .scheme $endpoint | default .scheme.default }}
+{{- $endpointHost := index .hosts $endpoint | default .hosts.default }}
+{{- $endpointPortMAP := index .port $port }}
+{{- $endpointPort := index $endpointPortMAP $endpoint | default (index $endpointPortMAP "default") }}
+{{- $endpointPath := index .path $endpoint | default .path.default | default "/" }}
+{{- $endpointClusterHostname := printf "%s.%s.%s" $endpointHost $namespace $clusterSuffix }}
+{{- $endpointHostname := index .host_fqdn_override $endpoint | default .host_fqdn_override.default | default $endpointClusterHostname }}
+{{- printf "%s://%s:%1.f%s" $endpointScheme $endpointHostname $endpointPort $endpointPath -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/endpoints/_service_name_endpoint_with_namespace_lookup.tpl
+++ b/helm-toolkit/templates/endpoints/_service_name_endpoint_with_namespace_lookup.tpl
@@ -1,0 +1,34 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns endpoint "<namespace>:<name>" pair from an endpoint
+# definition. This is used in kubernetes-entrypoint to support dependencies
+# between different services in different namespaces.
+# returns: the endpoint namespace and the service name, delimited by a colon
+
+{{- define "helm-toolkit.endpoints.service_name_endpoint_with_namespace_lookup" -}}
+{{- $type := index . 0 -}}
+{{- $endpoint := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $typeYamlSafe := $type | replace "-" "_" }}
+{{- $endpointMap := index $context.Values.endpoints $typeYamlSafe }}
+{{- with $endpointMap -}}
+{{- $endpointScheme := .scheme }}
+{{- $endpointName := index .hosts $endpoint | default .hosts.default}}
+{{- $endpointNamespace := .namespace | default $context.Release.Namespace }}
+{{- printf "%s:%s" $endpointNamespace $endpointName -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/scripts/_db-drop.py.tpl
+++ b/helm-toolkit/templates/scripts/_db-drop.py.tpl
@@ -1,0 +1,132 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.db_drop" }}
+#!/usr/bin/env python
+
+# Drops db and user for an OpenStack Service:
+# Set ROOT_DB_CONNECTION and DB_CONNECTION environment variables to contain
+# SQLAlchemy strings for the root connection to the database and the one you
+# wish the service to use. Alternatively, you can use an ini formatted config
+# at the location specified by OPENSTACK_CONFIG_FILE, and extract the string
+# from the key OPENSTACK_CONFIG_DB_KEY, in the section specified by
+# OPENSTACK_CONFIG_DB_SECTION.
+
+import os
+import sys
+import ConfigParser
+import logging
+from sqlalchemy import create_engine
+
+# Create logger, console handler and formatter
+logger = logging.getLogger('OpenStack-Helm DB Drop')
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# Set the formatter and add the handler
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
+# Get the connection string for the service db root user
+if "ROOT_DB_CONNECTION" in os.environ:
+    db_connection = os.environ['ROOT_DB_CONNECTION']
+    logger.info('Got DB root connection')
+else:
+    logger.critical('environment variable ROOT_DB_CONNECTION not set')
+    sys.exit(1)
+
+# Get the connection string for the service db
+if "OPENSTACK_CONFIG_FILE" in os.environ:
+    os_conf = os.environ['OPENSTACK_CONFIG_FILE']
+    if "OPENSTACK_CONFIG_DB_SECTION" in os.environ:
+        os_conf_section = os.environ['OPENSTACK_CONFIG_DB_SECTION']
+    else:
+        logger.critical('environment variable OPENSTACK_CONFIG_DB_SECTION not set')
+        sys.exit(1)
+    if "OPENSTACK_CONFIG_DB_KEY" in os.environ:
+        os_conf_key = os.environ['OPENSTACK_CONFIG_DB_KEY']
+    else:
+        logger.critical('environment variable OPENSTACK_CONFIG_DB_KEY not set')
+        sys.exit(1)
+    try:
+        config = ConfigParser.RawConfigParser()
+        logger.info("Using {0} as db config source".format(os_conf))
+        config.read(os_conf)
+        logger.info("Trying to load db config from {0}:{1}".format(
+            os_conf_section, os_conf_key))
+        user_db_conn = config.get(os_conf_section, os_conf_key)
+        logger.info("Got config from {0}".format(os_conf))
+    except:
+        logger.critical("Tried to load config from {0} but failed.".format(os_conf))
+        raise
+elif "DB_CONNECTION" in os.environ:
+    user_db_conn = os.environ['DB_CONNECTION']
+    logger.info('Got config from DB_CONNECTION env var')
+else:
+    logger.critical('Could not get db config, either from config file or env var')
+    sys.exit(1)
+
+# Root DB engine
+try:
+    root_engine_full = create_engine(db_connection)
+    root_user = root_engine_full.url.username
+    root_password = root_engine_full.url.password
+    drivername = root_engine_full.url.drivername
+    host = root_engine_full.url.host
+    port = root_engine_full.url.port
+    root_engine_url = ''.join([drivername, '://', root_user, ':', root_password, '@', host, ':', str (port)])
+    root_engine = create_engine(root_engine_url)
+    connection = root_engine.connect()
+    connection.close()
+    logger.info("Tested connection to DB @ {0}:{1} as {2}".format(
+        host, port, root_user))
+except:
+    logger.critical('Could not connect to database as root user')
+    raise
+
+# User DB engine
+try:
+    user_engine = create_engine(user_db_conn)
+    # Get our user data out of the user_engine
+    database = user_engine.url.database
+    user = user_engine.url.username
+    password = user_engine.url.password
+    logger.info('Got user db config')
+except:
+    logger.critical('Could not get user database config')
+    raise
+
+# Delete DB
+try:
+    root_engine.execute("DROP DATABASE IF EXISTS {0}".format(database))
+    logger.info("Deleted database {0}".format(database))
+except:
+    logger.critical("Could not drop database {0}".format(database))
+    raise
+
+# Delete DB User
+try:
+    root_engine.execute("DROP USER IF EXISTS {0}".format(user))
+    logger.info("Deleted user {0}".format(user))
+except:
+    logger.critical("Could not delete user {0}".format(user))
+    raise
+
+logger.info('Finished DB Management')
+{{- end }}

--- a/helm-toolkit/templates/scripts/_db-init.py.tpl
+++ b/helm-toolkit/templates/scripts/_db-init.py.tpl
@@ -1,0 +1,144 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.db_init" }}
+#!/usr/bin/env python
+
+# Creates db and user for an OpenStack Service:
+# Set ROOT_DB_CONNECTION and DB_CONNECTION environment variables to contain
+# SQLAlchemy strings for the root connection to the database and the one you
+# wish the service to use. Alternatively, you can use an ini formatted config
+# at the location specified by OPENSTACK_CONFIG_FILE, and extract the string
+# from the key OPENSTACK_CONFIG_DB_KEY, in the section specified by
+# OPENSTACK_CONFIG_DB_SECTION.
+
+import os
+import sys
+import ConfigParser
+import logging
+from sqlalchemy import create_engine
+
+# Create logger, console handler and formatter
+logger = logging.getLogger('OpenStack-Helm DB Init')
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# Set the formatter and add the handler
+ch.setFormatter(formatter)
+logger.addHandler(ch)
+
+
+# Get the connection string for the service db root user
+if "ROOT_DB_CONNECTION" in os.environ:
+    db_connection = os.environ['ROOT_DB_CONNECTION']
+    logger.info('Got DB root connection')
+else:
+    logger.critical('environment variable ROOT_DB_CONNECTION not set')
+    sys.exit(1)
+
+# Get the connection string for the service db
+if "OPENSTACK_CONFIG_FILE" in os.environ:
+    os_conf = os.environ['OPENSTACK_CONFIG_FILE']
+    if "OPENSTACK_CONFIG_DB_SECTION" in os.environ:
+        os_conf_section = os.environ['OPENSTACK_CONFIG_DB_SECTION']
+    else:
+        logger.critical('environment variable OPENSTACK_CONFIG_DB_SECTION not set')
+        sys.exit(1)
+    if "OPENSTACK_CONFIG_DB_KEY" in os.environ:
+        os_conf_key = os.environ['OPENSTACK_CONFIG_DB_KEY']
+    else:
+        logger.critical('environment variable OPENSTACK_CONFIG_DB_KEY not set')
+        sys.exit(1)
+    try:
+        config = ConfigParser.RawConfigParser()
+        logger.info("Using {0} as db config source".format(os_conf))
+        config.read(os_conf)
+        logger.info("Trying to load db config from {0}:{1}".format(
+            os_conf_section, os_conf_key))
+        user_db_conn = config.get(os_conf_section, os_conf_key)
+        logger.info("Got config from {0}".format(os_conf))
+    except:
+        logger.critical("Tried to load config from {0} but failed.".format(os_conf))
+        raise
+elif "DB_CONNECTION" in os.environ:
+    user_db_conn = os.environ['DB_CONNECTION']
+    logger.info('Got config from DB_CONNECTION env var')
+else:
+    logger.critical('Could not get db config, either from config file or env var')
+    sys.exit(1)
+
+# Root DB engine
+try:
+    root_engine_full = create_engine(db_connection)
+    root_user = root_engine_full.url.username
+    root_password = root_engine_full.url.password
+    drivername = root_engine_full.url.drivername
+    host = root_engine_full.url.host
+    port = root_engine_full.url.port
+    root_engine_url = ''.join([drivername, '://', root_user, ':', root_password, '@', host, ':', str (port)])
+    root_engine = create_engine(root_engine_url)
+    connection = root_engine.connect()
+    connection.close()
+    logger.info("Tested connection to DB @ {0}:{1} as {2}".format(
+        host, port, root_user))
+except:
+    logger.critical('Could not connect to database as root user')
+    raise
+
+# User DB engine
+try:
+    user_engine = create_engine(user_db_conn)
+    # Get our user data out of the user_engine
+    database = user_engine.url.database
+    user = user_engine.url.username
+    password = user_engine.url.password
+    logger.info('Got user db config')
+except:
+    logger.critical('Could not get user database config')
+    raise
+
+# Create DB
+try:
+    root_engine.execute("CREATE DATABASE IF NOT EXISTS {0}".format(database))
+    logger.info("Created database {0}".format(database))
+except:
+    logger.critical("Could not create database {0}".format(database))
+    raise
+
+# Create DB User
+try:
+    root_engine.execute(
+        "GRANT ALL ON `{0}`.* TO \'{1}\'@\'%%\' IDENTIFIED BY \'{2}\'".format(
+            database, user, password))
+    logger.info("Created user {0} for {1}".format(user, database))
+except:
+    logger.critical("Could not create user {0} for {1}".format(user, database))
+    raise
+
+# Test connection
+try:
+    connection = user_engine.connect()
+    connection.close()
+    logger.info("Tested connection to DB @ {0}:{1}/{2} as {3}".format(
+        host, port, database, user))
+except:
+    logger.critical('Could not connect to database as user')
+    raise
+
+logger.info('Finished DB Management')
+{{- end }}

--- a/helm-toolkit/templates/scripts/_ks-domain-user.sh.tpl
+++ b/helm-toolkit/templates/scripts/_ks-domain-user.sh.tpl
@@ -1,0 +1,74 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.keystone_domain_user" }}
+#!/bin/bash
+
+# Copyright 2017 Pete Birley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Manage domain
+SERVICE_OS_DOMAIN_ID=$(openstack domain create --or-show --enable -f value -c id \
+    --description="Service Domain for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_DOMAIN_NAME}" \
+    "${SERVICE_OS_DOMAIN_NAME}")
+
+# Display domain
+openstack domain show "${SERVICE_OS_DOMAIN_ID}"
+
+# Manage user
+SERVICE_OS_USERID=$(openstack user create --or-show --enable -f value -c id \
+    --domain="${SERVICE_OS_DOMAIN_ID}" \
+    --description "Service User for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_DOMAIN_NAME}" \
+    --password="${SERVICE_OS_PASSWORD}" \
+    "${SERVICE_OS_USERNAME}")
+
+# Manage user password (we do this to ensure the password is updated if required)
+openstack user set --password="${SERVICE_OS_PASSWORD}" "${SERVICE_OS_USERID}"
+
+# Display user
+openstack user show "${SERVICE_OS_USERID}"
+
+# Manage role
+SERVICE_OS_ROLE_ID=$(openstack role show -f value -c id \
+    "${SERVICE_OS_ROLE}" || openstack role create -f value -c id \
+    "${SERVICE_OS_ROLE}" )
+
+# Manage user role assignment
+openstack role add \
+          --domain="${SERVICE_OS_DOMAIN_ID}" \
+          --user="${SERVICE_OS_USERID}" \
+          --user-domain="${SERVICE_OS_DOMAIN_ID}" \
+          "${SERVICE_OS_ROLE_ID}"
+
+# Display user role assignment
+openstack role assignment list \
+          --role="${SERVICE_OS_ROLE_ID}" \
+          --user-domain="${SERVICE_OS_DOMAIN_ID}" \
+          --user="${SERVICE_OS_USERID}"
+{{- end }}

--- a/helm-toolkit/templates/scripts/_ks-endpoints.sh.tpl
+++ b/helm-toolkit/templates/scripts/_ks-endpoints.sh.tpl
@@ -1,0 +1,81 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.keystone_endpoints" }}
+#!/bin/bash
+
+# Copyright 2017 Pete Birley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Get Service ID
+OS_SERVICE_ID=$( openstack service list -f csv --quote none | \
+                  grep ",${OS_SERVICE_NAME},${OS_SERVICE_TYPE}$" | \
+                    sed -e "s/,${OS_SERVICE_NAME},${OS_SERVICE_TYPE}//g" )
+
+# Get Endpoint ID if it exists
+OS_ENDPOINT_ID=$( openstack endpoint list  -f csv --quote none | \
+                  grep "^[a-z0-9]*,${OS_REGION_NAME},${OS_SERVICE_NAME},${OS_SERVICE_TYPE},True,${OS_SVC_ENDPOINT}," | \
+                  awk -F ',' '{ print $1 }' )
+
+# Making sure only a single endpoint exists for a service within a region
+if [ "$(echo $OS_ENDPOINT_ID | wc -w)" -gt "1" ]; then
+  echo "More than one endpoint found, cleaning up"
+  for ENDPOINT_ID in $OS_ENDPOINT_ID; do
+    openstack endpoint delete ${ENDPOINT_ID}
+  done
+  unset OS_ENDPOINT_ID
+fi
+
+# Determine if Endpoint needs updated
+if [[ ${OS_ENDPOINT_ID} ]]; then
+  OS_ENDPOINT_URL_CURRENT=$(openstack endpoint show ${OS_ENDPOINT_ID} -f value -c url)
+  if [ "${OS_ENDPOINT_URL_CURRENT}" == "${OS_SERVICE_ENDPOINT}" ]; then
+    echo "Endpoints Match: no action required"
+    OS_ENDPOINT_UPDATE="False"
+  else
+    echo "Endpoints Dont Match: removing existing entries"
+    openstack endpoint delete ${OS_ENDPOINT_ID}
+    OS_ENDPOINT_UPDATE="True"
+  fi
+else
+  OS_ENDPOINT_UPDATE="True"
+fi
+
+# Update Endpoint if required
+if [[ "${OS_ENDPOINT_UPDATE}" == "True" ]]; then
+  OS_ENDPOINT_ID=$( openstack endpoint create -f value -c id \
+    --region="${OS_REGION_NAME}" \
+    "${OS_SERVICE_ID}" \
+    ${OS_SVC_ENDPOINT} \
+    "${OS_SERVICE_ENDPOINT}" )
+fi
+
+# Display the Endpoint
+openstack endpoint show ${OS_ENDPOINT_ID}
+{{- end }}

--- a/helm-toolkit/templates/scripts/_ks-service.sh.tpl
+++ b/helm-toolkit/templates/scripts/_ks-service.sh.tpl
@@ -1,0 +1,53 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.keystone_service" }}
+#!/bin/bash
+
+# Copyright 2017 Pete Birley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Service boilerplate description
+OS_SERVICE_DESC="${OS_REGION_NAME}: ${OS_SERVICE_NAME} (${OS_SERVICE_TYPE}) service"
+
+# Get Service ID if it exists
+unset OS_SERVICE_ID
+OS_SERVICE_ID=$( openstack service list -f csv --quote none | \
+                 grep ",${OS_SERVICE_NAME},${OS_SERVICE_TYPE}$" | \
+                 sed -e "s/,${OS_SERVICE_NAME},${OS_SERVICE_TYPE}//g" )
+
+# If a Service ID was not found, then create the service
+if [[ -z ${OS_SERVICE_ID} ]]; then
+  OS_SERVICE_ID=$(openstack service create -f value -c id \
+                  --name="${OS_SERVICE_NAME}" \
+                  --description "${OS_SERVICE_DESC}" \
+                  --enable \
+                  "${OS_SERVICE_TYPE}")
+fi
+{{- end }}

--- a/helm-toolkit/templates/scripts/_ks-user.sh.tpl
+++ b/helm-toolkit/templates/scripts/_ks-user.sh.tpl
@@ -1,0 +1,104 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.keystone_user" }}
+#!/bin/bash
+
+# Copyright 2017 Pete Birley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Manage project domain
+PROJECT_DOMAIN_ID=$(openstack domain create --or-show --enable -f value -c id \
+    --description="Domain for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_PROJECT_DOMAIN_NAME}" \
+    "${SERVICE_OS_PROJECT_DOMAIN_NAME}")
+
+# Display project domain
+openstack domain show "${PROJECT_DOMAIN_ID}"
+
+# Manage user project
+USER_PROJECT_DESC="Service Project for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_PROJECT_DOMAIN_NAME}"
+USER_PROJECT_ID=$(openstack project create --or-show --enable -f value -c id \
+    --domain="${PROJECT_DOMAIN_ID}" \
+    --description="${USER_PROJECT_DESC}" \
+    "${SERVICE_OS_PROJECT_NAME}");
+
+# Display project
+openstack project show "${USER_PROJECT_ID}"
+
+# Manage user domain
+USER_DOMAIN_ID=$(openstack domain create --or-show --enable -f value -c id \
+    --description="Domain for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_USER_DOMAIN_NAME}" \
+    "${SERVICE_OS_USER_DOMAIN_NAME}")
+
+# Display user domain
+openstack domain show "${USER_DOMAIN_ID}"
+
+# Manage user
+USER_DESC="Service User for ${SERVICE_OS_REGION_NAME}/${SERVICE_OS_USER_DOMAIN_NAME}/${SERVICE_OS_SERVICE_NAME}"
+USER_ID=$(openstack user create --or-show --enable -f value -c id \
+    --domain="${USER_DOMAIN_ID}" \
+    --project-domain="${PROJECT_DOMAIN_ID}" \
+    --project="${USER_PROJECT_ID}" \
+    --description="${USER_DESC}" \
+    --password="${SERVICE_OS_PASSWORD}" \
+    "${SERVICE_OS_USERNAME}");
+
+# Manage user password (we do this to ensure the password is updated if required)
+openstack user set --password="${SERVICE_OS_PASSWORD}" "${USER_ID}"
+
+# Display user
+openstack user show "${USER_ID}"
+
+function ks_assign_user_role () {
+  # Manage user role assignment
+  openstack role add \
+      --user="${USER_ID}" \
+      --user-domain="${USER_DOMAIN_ID}" \
+      --project-domain="${PROJECT_DOMAIN_ID}" \
+      --project="${USER_PROJECT_ID}" \
+      "${USER_ROLE_ID}"
+
+  # Display user role assignment
+  openstack role assignment list \
+      --role="${USER_ROLE_ID}" \
+      --user-domain="${USER_DOMAIN_ID}" \
+      --user="${USER_ID}"
+}
+
+# Manage user service role
+export USER_ROLE_ID=$(openstack role create --or-show -f value -c id \
+    "${SERVICE_OS_ROLE}");
+ks_assign_user_role
+
+# Manage user member role
+: ${MEMBER_OS_ROLE:="_member_"}
+export USER_ROLE_ID=$(openstack role create --or-show -f value -c id \
+    "${MEMBER_OS_ROLE}");
+ks_assign_user_role
+{{- end }}

--- a/helm-toolkit/templates/scripts/_rally_test.sh.tpl
+++ b/helm-toolkit/templates/scripts/_rally_test.sh.tpl
@@ -1,0 +1,37 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.scripts.rally_test" -}}
+#!/bin/bash
+set -ex
+{{- $rallyTests := index . 0 }}
+
+: ${RALLY_ENV_NAME:="openstack-helm"}
+rally-manage db create
+rally deployment create --fromenv --name ${RALLY_ENV_NAME}
+rally deployment use ${RALLY_ENV_NAME}
+rally deployment check
+{{- if $rallyTests.run_tempest }}
+rally verify create-verifier --name ${RALLY_ENV_NAME}-tempest --type tempest
+SERVICE_TYPE=$(rally deployment check | grep ${RALLY_ENV_NAME} | awk -F \| '{print $3}' | tr -d ' ' | tr -d '\n')
+rally verify start --pattern tempest.api.$SERVICE_TYPE*
+rally verify delete-verifier --id ${RALLY_ENV_NAME}-tempest --force
+{{- end }}
+rally task validate /etc/rally/rally_tests.yaml
+rally task start /etc/rally/rally_tests.yaml
+rally deployment destroy --deployment ${RALLY_ENV_NAME}
+rally task sla-check
+{{- end }}

--- a/helm-toolkit/templates/snippets/_keystone_openrc_env_vars.tpl
+++ b/helm-toolkit/templates/snippets/_keystone_openrc_env_vars.tpl
@@ -1,0 +1,56 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.keystone_openrc_env_vars" }}
+{{- $ksUserSecret := .ksUserSecret }}
+- name: OS_IDENTITY_API_VERSION
+  value: "3"
+- name: OS_AUTH_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_AUTH_URL
+- name: OS_REGION_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_REGION_NAME
+- name: OS_PROJECT_DOMAIN_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PROJECT_DOMAIN_NAME
+- name: OS_PROJECT_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PROJECT_NAME
+- name: OS_USER_DOMAIN_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_USER_DOMAIN_NAME
+- name: OS_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_USERNAME
+- name: OS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PASSWORD
+{{- end }}

--- a/helm-toolkit/templates/snippets/_keystone_secret_openrc.tpl
+++ b/helm-toolkit/templates/snippets/_keystone_secret_openrc.tpl
@@ -1,0 +1,29 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.keystone_secret_openrc" }}
+{{- $userClass := index . 0 -}}
+{{- $identityEndpoint := index . 1 -}}
+{{- $context := index . 2 -}}
+{{- $userContext := index $context.Values.endpoints.identity.auth $userClass }}
+OS_AUTH_URL: {{ tuple "identity" $identityEndpoint "api" $context | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | b64enc }}
+OS_REGION_NAME: {{  $userContext.region_name | b64enc }}
+OS_PROJECT_DOMAIN_NAME: {{  $userContext.project_domain_name | b64enc }}
+OS_PROJECT_NAME: {{  $userContext.project_name | b64enc }}
+OS_USER_DOMAIN_NAME: {{  $userContext.user_domain_name | b64enc }}
+OS_USERNAME: {{  $userContext.username | b64enc }}
+OS_PASSWORD: {{  $userContext.password | b64enc }}
+{{- end }}

--- a/helm-toolkit/templates/snippets/_keystone_user_create_env_vars.tpl
+++ b/helm-toolkit/templates/snippets/_keystone_user_create_env_vars.tpl
@@ -1,0 +1,49 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.keystone_user_create_env_vars" }}
+{{- $ksUserSecret := .ksUserSecret }}
+- name: SERVICE_OS_REGION_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_REGION_NAME
+- name: SERVICE_OS_PROJECT_DOMAIN_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PROJECT_DOMAIN_NAME
+- name: SERVICE_OS_PROJECT_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PROJECT_NAME
+- name: SERVICE_OS_USER_DOMAIN_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_USER_DOMAIN_NAME
+- name: SERVICE_OS_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_USERNAME
+- name: SERVICE_OS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ksUserSecret }}
+      key: OS_PASSWORD
+{{- end }}

--- a/helm-toolkit/templates/snippets/_kubernetes_entrypoint_init_container.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_entrypoint_init_container.tpl
@@ -1,0 +1,51 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_entrypoint_init_container" -}}
+{{- $envAll := index . 0 -}}
+{{- $deps := index . 1 -}}
+{{- $mounts := index . 2 -}}
+- name: init
+  image: {{ $envAll.Values.images.tags.dep_check }}
+  imagePullPolicy: {{ $envAll.Values.images.pull_policy }}
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.namespace
+    - name: INTERFACE_NAME
+      value: eth0
+    - name: DEPENDENCY_SERVICE
+      value: "{{ tuple $deps.services $envAll | include "helm-toolkit.utils.comma_joined_service_list" }}"
+    - name: DEPENDENCY_JOBS
+      value: "{{  include "helm-toolkit.utils.joinListWithComma" $deps.jobs }}"
+    - name: DEPENDENCY_DAEMONSET
+      value: "{{  include "helm-toolkit.utils.joinListWithComma" $deps.daemonset }}"
+    - name: DEPENDENCY_CONTAINER
+      value: "{{  include "helm-toolkit.utils.joinListWithComma" $deps.container }}"
+    - name: COMMAND
+      value: "echo done"
+  command:
+    - kubernetes-entrypoint
+  volumeMounts:
+{{ toYaml $mounts | indent 4 }}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_kubectl_params.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_kubectl_params.tpl
@@ -1,0 +1,22 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_kubectl_params" -}}
+{{- $envAll := index . 0 -}}
+{{- $application := index . 1 -}}
+{{- $component := index . 2 -}}
+{{ print "-l application=" $application " -l component=" $component }}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_metadata_labels.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_metadata_labels.tpl
@@ -1,0 +1,24 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_metadata_labels" -}}
+{{- $envAll := index . 0 -}}
+{{- $application := index . 1 -}}
+{{- $component := index . 2 -}}
+release_group: {{ $envAll.Values.release_group | default $envAll.Release.Name }}
+application: {{ $application }}
+component: {{ $component }}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_pod_anti_affinity.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_pod_anti_affinity.tpl
@@ -1,0 +1,42 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_pod_anti_affinity" -}}
+{{- $envAll := index . 0 -}}
+{{- $application := index . 1 -}}
+{{- $component := index . 2 -}}
+{{- $antiAffinityType := index $envAll.Values.pod.affinity.anti.type $component | default $envAll.Values.pod.affinity.anti.type.default }}
+{{- $antiAffinityKey := index $envAll.Values.pod.affinity.anti.topologyKey $component | default $envAll.Values.pod.affinity.anti.topologyKey.default }}
+podAntiAffinity:
+  {{ $antiAffinityType }}:
+  - podAffinityTerm:
+      labelSelector:
+        matchExpressions:
+        - key: release_group
+          operator: In
+          values:
+            - {{ $envAll.Values.release_group | default $envAll.Release.Name }}
+        - key: application
+          operator: In
+          values:
+            - {{ $application }}
+        - key: component
+          operator: In
+          values:
+            - {{ $component }}
+      topologyKey: {{ $antiAffinityKey }}
+    weight: 10
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_pod_rbac_roles.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_pod_rbac_roles.tpl
@@ -1,0 +1,68 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_pod_rbac_roles" -}}
+{{- $envAll := index . 0 -}}
+{{- $deps := index . 1 -}}
+{{- $saName := index . 2 | replace "_" "-" }}
+{{- $saNamespace := index . 3 -}}
+{{- $releaseName := $envAll.Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ $releaseName }}-{{ $saName }}
+  namespace: {{ $saNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $releaseName }}-{{ $saNamespace }}-{{ $saName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $saNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ $releaseName }}-{{ $saNamespace }}-{{ $saName }}
+  namespace: {{ $saNamespace }}
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+      - batch
+      - apps
+    verbs:
+      - get
+      - list
+    resources:
+      {{- range $k, $v := $deps -}}
+      {{ if eq $v "daemonsets" }}
+      - daemonsets
+      {{- end -}}
+      {{ if eq $v "jobs" }}
+      - jobs
+      {{- end -}}
+      {{ if or (eq $v "daemonsets") (eq $v "jobs") }}
+      - pods
+      {{- end -}}
+      {{ if eq $v "services" }}
+      - services
+      - endpoints
+      {{- end -}}
+      {{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_pod_rbac_serviceaccount.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_pod_rbac_serviceaccount.tpl
@@ -1,0 +1,50 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" -}}
+{{- $envAll := index . 0 -}}
+{{- $deps := index . 1 -}}
+{{- $saName := index . 2 -}}
+{{- $saNamespace := $envAll.Release.Namespace }}
+{{- $randomKey := randAlphaNum 32 }}
+{{- $allNamespace := dict $randomKey "" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $saNamespace }}
+{{- range $k, $v := $deps -}}
+{{- if eq $k "services" }}
+{{- range $serv := $v }}
+{{- $endpointMap := index $envAll.Values.endpoints $serv.service }}
+{{- $endpointNS := $endpointMap.namespace | default $saNamespace }}
+{{- if not (contains "services" ((index $allNamespace $endpointNS) | default "")) }}
+{{- $_ := set $allNamespace $endpointNS (printf "%s%s" "services," ((index $allNamespace $endpointNS) | default "")) }}
+{{- end -}}
+{{- end -}}
+{{- else if and (eq $k "jobs") $v }}
+{{- $_ := set $allNamespace $saNamespace  (printf "%s%s" "jobs," ((index $allNamespace $saNamespace) | default "")) }}
+{{- else if and (eq $k "daemonset") $v }}
+{{- $_ := set $allNamespace $saNamespace  (printf "%s%s" "daemonsets," ((index $allNamespace $saNamespace) | default "")) }}
+{{- end -}}
+{{- end -}}
+{{- $_ := unset $allNamespace $randomKey }}
+{{- range $ns, $vv := $allNamespace }}
+{{- $resourceList := (splitList "," (trimSuffix "," $vv)) }}
+{{- tuple $envAll $resourceList $saName $ns | include "helm-toolkit.snippets.kubernetes_pod_rbac_roles" }}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_resources.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_resources.tpl
@@ -1,0 +1,29 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_resources" -}}
+{{- $envAll := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- if $envAll.Values.pod.resources.enabled -}}
+resources:
+  limits:
+    cpu: {{ $component.limits.cpu | quote }}
+    memory: {{ $component.limits.memory | quote }}
+  requests:
+    cpu: {{ $component.requests.cpu | quote }}
+    memory: {{ $component.requests.memory | quote }}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_upgrades_daemonset.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_upgrades_daemonset.tpl
@@ -1,0 +1,35 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_upgrades_daemonset" -}}
+{{- $envAll := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- $upgradeMap := index $envAll.Values.pod.lifecycle.upgrades.daemonsets $component -}}
+{{- $pod_replacement_strategy := $envAll.Values.pod.lifecycle.upgrades.daemonsets.pod_replacement_strategy -}}
+{{- with $upgradeMap -}}
+{{- if .enabled }}
+minReadySeconds: {{ .min_ready_seconds }}
+updateStrategy:
+  type: {{ $pod_replacement_strategy }}
+  {{- if $pod_replacement_strategy }}
+  {{- if eq $pod_replacement_strategy "RollingUpdate" }}
+  rollingUpdate:
+    maxUnavailable: {{ .max_unavailable }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_kubernetes_upgrades_deployment.tpl
+++ b/helm-toolkit/templates/snippets/_kubernetes_upgrades_deployment.tpl
@@ -1,0 +1,29 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.snippets.kubernetes_upgrades_deployment" -}}
+{{- $envAll := index . 0 -}}
+{{- with $envAll.Values.pod.lifecycle.upgrades.deployments -}}
+revisionHistoryLimit: {{ .revision_history }}
+strategy:
+  type: {{ .pod_replacement_strategy }}
+  {{- if eq .pod_replacement_strategy "RollingUpdate" }}
+  rollingUpdate:
+    maxUnavailable: {{ .rolling_update.max_unavailable }}
+    maxSurge: {{ .rolling_update.max_surge }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_prometheus_pod_annotations.tpl
+++ b/helm-toolkit/templates/snippets/_prometheus_pod_annotations.tpl
@@ -1,0 +1,35 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# Appends annotations for configuring prometheus scrape jobs via pod
+# annotations. The required annotations are:
+# * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+# * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+# * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+# pod's declared ports (default is a port-free target if none are declared).
+
+{{- define "helm-toolkit.snippets.prometheus_pod_annotations" -}}
+{{- $config := index . 0 -}}
+{{- if $config.scrape }}
+prometheus.io/scrape: {{ $config.scrape | quote }}
+{{- end }}
+{{- if $config.path }}
+prometheus.io/path: {{ $config.path | quote }}
+{{- end }}
+{{- if $config.port }}
+prometheus.io/port: {{ $config.port | quote }}
+{{- end }}
+{{- end -}}

--- a/helm-toolkit/templates/snippets/_prometheus_service_annotations.tpl
+++ b/helm-toolkit/templates/snippets/_prometheus_service_annotations.tpl
@@ -1,0 +1,37 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# Appends annotations for configuring prometheus scrape endpoints via
+# annotations. The required annotations are:
+# * `prometheus.io/scrape`: Only scrape services that have a value of `true`
+# * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
+# to set this to `https` & most likely set the `tls_config` of the scrape config.
+# * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+# * `prometheus.io/port`: If the metrics are exposed on a different port to the
+# service then set this appropriately.
+
+{{- define "helm-toolkit.snippets.prometheus_service_annotations" -}}
+{{- $config := index . 0 -}}
+{{- if $config.scrape }}
+prometheus.io/scrape: {{ $config.scrape | quote }}
+{{- end }}
+{{- if $config.scheme }}
+prometheus.io/scheme: {{ $config.scheme | quote }}
+{{- end }}
+{{- if $config.path }}
+prometheus.io/path: {{ $config.path | quote }}
+{{- end }}
+{{- if $config.port }}
+prometheus.io/port: {{ $config.port | quote }}
+{{- end }}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_comma_joined_service_list.tpl
+++ b/helm-toolkit/templates/utils/_comma_joined_service_list.tpl
@@ -1,0 +1,21 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.comma_joined_service_list" -}}
+{{- $deps := index . 0 -}}
+{{- $envAll := index . 1 -}}
+{{- range $k, $v := $deps -}}{{- if $k -}},{{- end -}}{{ tuple $v.service $v.endpoint $envAll | include "helm-toolkit.endpoints.service_name_endpoint_with_namespace_lookup" }}{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_configmap_templater.tpl
+++ b/helm-toolkit/templates/utils/_configmap_templater.tpl
@@ -1,0 +1,32 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.configmap_templater" }}
+{{- $keyRoot := index . 0 -}}
+{{- $configTemplate := index . 1 -}}
+{{- $context := index . 2 -}}
+{{ if $keyRoot.override -}}
+{{ $keyRoot.override | indent 4 }}
+{{- else -}}
+{{- if $keyRoot.prefix -}}
+{{ $keyRoot.prefix | indent 4 }}
+{{- end }}
+{{ tuple $configTemplate $context | include "helm-toolkit.utils.template" | indent 4 }}
+{{- end }}
+{{- if $keyRoot.append -}}
+{{ $keyRoot.append | indent 4 }}
+{{- end }}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_daemonset_overrides.tpl
+++ b/helm-toolkit/templates/utils/_daemonset_overrides.tpl
@@ -1,0 +1,271 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.daemonset_overrides" }}
+  {{- $daemonset := index . 0 }}
+  {{- $daemonset_yaml := index . 1 }}
+  {{- $configmap_include := index . 2 }}
+  {{- $configmap_name := index . 3 }}
+  {{- $context := index . 4 }}
+  {{- $_ := unset $context ".Files" }}
+  {{- $_ := set $context.Values "__daemonset_yaml" $daemonset_yaml }}
+  {{- $daemonset_root_name := printf (print $context.Chart.Name "_" $daemonset) }}
+  {{- $_ := set $context.Values "__daemonset_list" list }}
+  {{- $_ := set $context.Values "__default" dict }}
+  {{- if hasKey $context.Values.conf "overrides" }}
+    {{- range $key, $val := $context.Values.conf.overrides }}
+
+      {{- if eq $key $daemonset_root_name }}
+        {{- range $type, $type_data := . }}
+
+          {{- if eq $type "hosts" }}
+            {{- range $host_data := . }}
+              {{/* dictionary that will contain all info needed to generate this
+              iteration of the daemonset */}}
+              {{- $current_dict := dict }}
+
+              {{/* set daemonset name */}}
+              {{- $_ := set $current_dict "name" $host_data.name }}
+
+              {{/* apply overrides */}}
+              {{- $override_conf_copy := $host_data.conf }}
+              {{- $root_conf_copy := omit $context.Values.conf "overrides" }}
+              {{- $merged_dict := merge $override_conf_copy $root_conf_copy }}
+              {{- $root_conf_copy2 := dict "conf" $merged_dict }}
+              {{- $context_values := omit $context.Values "conf" }}
+              {{- $root_conf_copy3 := merge $context_values $root_conf_copy2 }}
+              {{- $root_conf_copy4 := dict "Values" $root_conf_copy3 }}
+              {{- $_ := set $current_dict "nodeData" $root_conf_copy4 }}
+
+              {{/* Schedule to this host explicitly. */}}
+              {{- $nodeSelector_dict := dict }}
+
+              {{- $_ := set $nodeSelector_dict "key" "kubernetes.io/hostname" }}
+              {{- $_ := set $nodeSelector_dict "operator" "In" }}
+
+              {{- $values_list := list $host_data.name }}
+              {{- $_ := set $nodeSelector_dict "values" $values_list }}
+
+              {{- $list_aggregate := list $nodeSelector_dict }}
+              {{- $_ := set $current_dict "matchExpressions" $list_aggregate }}
+
+              {{/* store completed daemonset entry/info into global list */}}
+              {{- $list_aggregate := append $context.Values.__daemonset_list $current_dict }}
+              {{- $_ := set $context.Values "__daemonset_list" $list_aggregate }}
+
+            {{- end }}
+          {{- end }}
+
+          {{- if eq $type "labels" }}
+            {{- $_ := set $context.Values "__label_list" . }}
+            {{- range $label_data := . }}
+              {{/* dictionary that will contain all info needed to generate this
+              iteration of the daemonset. */}}
+              {{- $_ := set $context.Values "__current_label" dict }}
+
+              {{/* set daemonset name */}}
+              {{- $_ := set $context.Values.__current_label "name" $label_data.label.key }}
+
+              {{/* apply overrides */}}
+              {{- $override_conf_copy := $label_data.conf }}
+              {{- $root_conf_copy := omit $context.Values.conf "overrides" }}
+              {{- $merged_dict := merge $override_conf_copy $root_conf_copy }}
+              {{- $root_conf_copy2 := dict "conf" $merged_dict }}
+              {{- $context_values := omit $context.Values "conf" }}
+              {{- $root_conf_copy3 := merge $context_values $root_conf_copy2 }}
+              {{- $root_conf_copy4 := dict "Values" $root_conf_copy3 }}
+              {{- $_ := set $context.Values.__current_label "nodeData" $root_conf_copy4 }}
+
+              {{/* Schedule to the provided label value(s) */}}
+              {{- $label_dict := omit $label_data.label "NULL" }}
+              {{- $_ := set $label_dict "operator" "In" }}
+              {{- $list_aggregate := list $label_dict }}
+              {{- $_ := set $context.Values.__current_label "matchExpressions" $list_aggregate }}
+
+              {{/* Do not schedule to other specified labels, with higher
+              precedence as the list position increases. Last defined label
+              is highest priority. */}}
+              {{- $other_labels := without $context.Values.__label_list $label_data }}
+              {{- range $label_data2 := $other_labels }}
+                {{- $label_dict := omit $label_data2.label "NULL" }}
+
+                {{- $_ := set $label_dict "operator" "NotIn" }}
+
+                {{- $list_aggregate := append $context.Values.__current_label.matchExpressions $label_dict }}
+                {{- $_ := set $context.Values.__current_label "matchExpressions" $list_aggregate }}
+              {{- end }}
+              {{- $_ := set $context.Values "__label_list" $other_labels }}
+
+              {{/* Do not schedule to any other specified hosts */}}
+              {{- range $type, $type_data := $val }}
+                {{- if eq $type "hosts" }}
+                  {{- range $host_data := . }}
+                    {{- $label_dict := dict }}
+
+                    {{- $_ := set $label_dict "key" "kubernetes.io/hostname" }}
+                    {{- $_ := set $label_dict "operator" "NotIn" }}
+
+                    {{- $values_list := list $host_data.name }}
+                    {{- $_ := set $label_dict "values" $values_list }}
+
+                    {{- $list_aggregate := append $context.Values.__current_label.matchExpressions $label_dict }}
+                    {{- $_ := set $context.Values.__current_label "matchExpressions" $list_aggregate }}
+                  {{- end }}
+                {{- end }}
+              {{- end }}
+
+              {{/* store completed daemonset entry/info into global list */}}
+              {{- $list_aggregate := append $context.Values.__daemonset_list $context.Values.__current_label }}
+              {{- $_ := set $context.Values "__daemonset_list" $list_aggregate }}
+              {{- $_ := unset $context.Values "__current_label" }}
+
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
+        {{/* scheduler exceptions for the default daemonset */}}
+        {{- $_ := set $context.Values.__default "matchExpressions" list }}
+
+        {{- range $type, $type_data := . }}
+          {{/* Do not schedule to other specified labels */}}
+          {{- if eq $type "labels" }}
+            {{- range $label_data := . }}
+              {{- $default_dict := omit $label_data.label "NULL" }}
+
+              {{- $_ := set $default_dict "operator" "NotIn" }}
+
+              {{- $list_aggregate := append $context.Values.__default.matchExpressions $default_dict }}
+              {{- $_ := set $context.Values.__default "matchExpressions" $list_aggregate }}
+            {{- end }}
+          {{- end }}
+          {{/* Do not schedule to other specified hosts */}}
+          {{- if eq $type "hosts" }}
+            {{- range $host_data := . }}
+              {{- $default_dict := dict }}
+
+              {{- $_ := set $default_dict "key" "kubernetes.io/hostname" }}
+              {{- $_ := set $default_dict "operator" "NotIn" }}
+
+              {{- $values_list := list $host_data.name }}
+              {{- $_ := set $default_dict "values" $values_list }}
+
+              {{- $list_aggregate := append $context.Values.__default.matchExpressions $default_dict }}
+              {{- $_ := set $context.Values.__default "matchExpressions" $list_aggregate }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{/* generate the default daemonset */}}
+
+  {{/* set name */}}
+  {{- $_ := set $context.Values.__default "name" "default" }}
+
+  {{/* no overrides apply, so copy as-is */}}
+  {{- $root_conf_copy1 := omit $context.Values.conf "overrides" }}
+  {{- $root_conf_copy2 := dict "conf" $root_conf_copy1 }}
+  {{- $context_values := omit $context.Values "conf" }}
+  {{- $root_conf_copy3 := merge $context_values $root_conf_copy2 }}
+  {{- $root_conf_copy4 := dict "Values" $root_conf_copy3 }}
+  {{- $_ := set $context.Values.__default "nodeData" $root_conf_copy4 }}
+
+  {{/* add to global list */}}
+  {{- $list_aggregate := append $context.Values.__daemonset_list $context.Values.__default }}
+  {{- $_ := set $context.Values "__daemonset_list" $list_aggregate }}
+
+  {{- $_ := set $context.Values "__last_configmap_name" $configmap_name }}
+  {{- range $current_dict := $context.Values.__daemonset_list }}
+
+    {{- $context_novalues := omit $context "Values" }}
+    {{- $merged_dict := merge $current_dict.nodeData $context_novalues }}
+    {{- $_ := set $current_dict "nodeData" $merged_dict }}
+
+    {{/* name needs to be a DNS-1123 compliant name. Ensure lower case */}}
+    {{- $name_format1 := printf (print $daemonset_root_name "-" $current_dict.name) | lower }}
+    {{/* labels may contain underscores which would be invalid here, so we replace them with dashes
+    there may be other valid label names which would make for an invalid DNS-1123 name
+    but these will be easier to handle in future with sprig regex* functions
+    (not availabile in helm 2.5.1) */}}
+    {{- $name_format2 := $name_format1 | replace "_" "-" }}
+    {{/* To account for the case where the same label is defined multiple times in overrides
+    (but with different label values), we add a sha of the scheduling data to ensure
+    name uniqueness */}}
+    {{- $_ := set $current_dict "dns_1123_name" dict }}
+    {{- if hasKey $current_dict "matchExpressions" }}
+      {{- $_ := set $current_dict "dns_1123_name" (printf (print $name_format2 "-" ($current_dict.matchExpressions | quote | sha256sum | trunc 8))) }}
+    {{- else }}
+      {{- $_ := set $current_dict "dns_1123_name" $name_format2 }}
+    {{- end }}
+
+    {{/* set daemonset metadata name */}}
+    {{- if not $context.Values.__daemonset_yaml.metadata }}{{- $_ := set $context.Values.__daemonset_yaml "metadata" dict }}{{- end }}
+    {{- if not $context.Values.__daemonset_yaml.metadata.name }}{{- $_ := set $context.Values.__daemonset_yaml.metadata "name" dict }}{{- end }}
+    {{- $_ := set $context.Values.__daemonset_yaml.metadata "name" $current_dict.dns_1123_name }}
+
+    {{/* set container name
+    assume not more than one container is defined */}}
+    {{- $container := first $context.Values.__daemonset_yaml.spec.template.spec.containers }}
+    {{- $_ := set $container "name" $current_dict.dns_1123_name }}
+    {{- $cont_list := list $container }}
+    {{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec "containers" $cont_list }}
+
+    {{/* cross-reference configmap name to container volume definitions */}}
+    {{- $_ := set $context.Values "__volume_list" list }}
+    {{- range $current_volume := $context.Values.__daemonset_yaml.spec.template.spec.volumes }}
+      {{- $_ := set $context.Values "__volume" $current_volume }}
+      {{- if hasKey $context.Values.__volume "configMap" }}
+        {{- if eq $context.Values.__volume.configMap.name $context.Values.__last_configmap_name }}
+          {{- $_ := set $context.Values.__volume.configMap "name" $current_dict.dns_1123_name }}
+        {{- end }}
+      {{- end }}
+      {{- $updated_list := append $context.Values.__volume_list $context.Values.__volume }}
+      {{- $_ := set $context.Values "__volume_list" $updated_list }}
+    {{- end }}
+    {{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec "volumes" $context.Values.__volume_list }}
+
+
+    {{/* populate scheduling restrictions */}}
+    {{- if hasKey $current_dict "matchExpressions" }}
+      {{- if not $context.Values.__daemonset_yaml.spec.template.spec }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template "spec" dict }}{{- end }}
+      {{- if not $context.Values.__daemonset_yaml.spec.template.spec.affinity }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec "affinity" dict }}{{- end }}
+      {{- if not $context.Values.__daemonset_yaml.spec.template.spec.affinity.nodeAffinity }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec.affinity "nodeAffinity" dict }}{{- end }}
+      {{- if not $context.Values.__daemonset_yaml.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec.affinity.nodeAffinity "requiredDuringSchedulingIgnoredDuringExecution" dict }}{{- end }}
+      {{- $match_exprs := dict }}
+      {{- $_ := set $match_exprs "matchExpressions" $current_dict.matchExpressions }}
+      {{- $appended_match_expr := list $match_exprs }}
+      {{- $_ := set $context.Values.__daemonset_yaml.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution "nodeSelectorTerms" $appended_match_expr }}
+    {{- end }}
+
+    {{/* input value hash for current set of values overrides */}}
+    {{- if not $context.Values.__daemonset_yaml.spec }}{{- $_ := set $context.Values.__daemonset_yaml "spec" dict }}{{- end }}
+    {{- if not $context.Values.__daemonset_yaml.spec.template }}{{- $_ := set $context.Values.__daemonset_yaml.spec "template" dict }}{{- end }}
+    {{- if not $context.Values.__daemonset_yaml.spec.template.metadata }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template "metadata" dict }}{{- end }}
+    {{- if not $context.Values.__daemonset_yaml.spec.template.metadata.annotations }}{{- $_ := set $context.Values.__daemonset_yaml.spec.template.metadata "annotations" dict }}{{- end }}
+    {{- $cmap := list $current_dict.dns_1123_name $current_dict.nodeData | include $configmap_include }}
+    {{- $values_hash := $cmap | quote | sha256sum }}
+    {{- $_ := set $context.Values.__daemonset_yaml.spec.template.metadata.annotations "configmap-etc-hash" $values_hash }}
+
+    {{/* generate configmap */}}
+---
+{{ $cmap }}
+    {{/* generate daemonset yaml */}}
+---
+{{ $context.Values.__daemonset_yaml | toYaml }}
+    {{- $_ := set $context.Values "__last_configmap_name" $current_dict.dns_1123_name }}
+  {{- end }}
+{{- end }}

--- a/helm-toolkit/templates/utils/_hash.tpl
+++ b/helm-toolkit/templates/utils/_hash.tpl
@@ -1,0 +1,23 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.hash" -}}
+{{- $name := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $last := base $context.Template.Name }}
+{{- $wtf := $context.Template.Name | replace $last $name -}}
+{{- include $wtf $context | sha256sum | quote -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_joinListWithComma.tpl
+++ b/helm-toolkit/templates/utils/_joinListWithComma.tpl
@@ -1,0 +1,20 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_joinListWithSpace.tpl
+++ b/helm-toolkit/templates/utils/_joinListWithSpace.tpl
@@ -1,0 +1,20 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.joinListWithSpace" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}}{{- " " -}}{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_template.tpl
+++ b/helm-toolkit/templates/utils/_template.tpl
@@ -1,0 +1,23 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.template" -}}
+{{- $name := index . 0 -}}
+{{- $context := index . 1 -}}
+{{- $last := base $context.Template.Name }}
+{{- $wtf := $context.Template.Name | replace $last $name -}}
+{{ include $wtf $context }}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_to_ini.tpl
+++ b/helm-toolkit/templates/utils/_to_ini.tpl
@@ -1,0 +1,30 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.to_ini" -}}
+{{- range $section, $values := . -}}
+{{- if kindIs "map" $values -}}
+[{{ $section }}]
+{{range $key, $value := $values -}}
+{{- if kindIs "slice" $value -}}
+{{ $key }} = {{ include "helm-toolkit.utils.joinListWithComma" $value }}
+{{else -}}
+{{ $key }} = {{ $value }}
+{{end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_to_k8s_env_vars.tpl
+++ b/helm-toolkit/templates/utils/_to_k8s_env_vars.tpl
@@ -1,0 +1,27 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.to_k8s_env_vars" -}}
+{{range $key, $value := . -}}
+{{- if kindIs "slice" $value -}}
+- name: {{ $key }}
+  value: {{ include "helm-toolkit.utils.joinListWithComma" $value | quote }}
+{{else -}}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{ end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_to_kv_list.tpl
+++ b/helm-toolkit/templates/utils/_to_kv_list.tpl
@@ -1,0 +1,48 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function returns key value pair in the INI format (key = value)
+# as needed by openstack config files
+#
+# Sample key value pair format:
+# conf:
+#   libvirt:
+#     log_level: 3
+# Usage:
+# { include "helm-toolkit.utils.to_kv_list" .Values.conf.libvirt }
+# returns: log_level = 3
+
+{{- define "helm-toolkit.utils.to_kv_list" -}}
+{{- range $key, $value :=  . -}}
+{{- if kindIs "slice" $value }}
+{{ $key }} = [{{ range $value -}}
+{{- if regexMatch "^[0-9]+$" . -}}
+{{- . -}},
+{{- else -}}
+{{- . | quote -}},
+{{- end }}
+{{- end }}]
+{{- else if kindIs "string" $value }}
+{{- if regexMatch "^[0-9]+$" $value }}
+{{ $key }} = {{ $value }}
+{{- else }}
+{{ $key }} = {{ $value | quote }}
+{{- end }}
+{{- else }}
+{{ $key }} = {{ $value }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/templates/utils/_to_oslo_conf.tpl
+++ b/helm-toolkit/templates/utils/_to_oslo_conf.tpl
@@ -1,0 +1,36 @@
+{{/*
+Copyright 2017 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "helm-toolkit.utils.to_oslo_conf" -}}
+{{- range $section, $values := . -}}
+{{- if kindIs "map" $values -}}
+[{{ $section }}]
+{{ range $key, $value := $values -}}
+{{- if kindIs "slice" $value -}}
+{{ $key }} = {{ include "helm-toolkit.utils.joinListWithComma" $value }}
+{{ else if kindIs "map" $value -}}
+{{- if eq $value.type "multistring" }}
+{{- range $k, $multistringValue := $value.values -}}
+{{ $key }} = {{ $multistringValue }}
+{{ end -}}
+{{- end -}}
+{{- else -}}
+{{ $key }} = {{ $value }}
+{{ end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-toolkit/values.yaml
+++ b/helm-toolkit/values.yaml
@@ -1,0 +1,26 @@
+# Copyright 2017 The Openstack-Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for utils.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+global:
+  region: cluster
+  tld: local
+
+endpoints:
+  fqdn: null
+


### PR DESCRIPTION
We have moved helm-toolkit code along with the commits from openstack-helm. There are really useful functions which are defined in the helm-toolkit which will be used in the contrail-helm-deployer repo